### PR TITLE
Add Telegram mini app with bottom navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
-# Pinbax Fun Site
+# Telegram Mini App Demo
 
-This repository contains a simple static site inspired by the website `pinbax.fun`. The page uses [Tailwind CSS](https://tailwindcss.com/) and the Google font "Lobster" to create a playful design.
+This project contains a simple example of a Telegram mini‑app. It showcases five
+pages that can be switched using a bottom navigation bar:
 
-Open `index.html` in your browser or serve the directory with any static file server to view the site.
+1. “Лидерборд”
+2. “Задание”
+3. “Главная”
+4. “Мои коллекции”
+5. “Настройки”
+
+The layout uses [Tailwind CSS](https://tailwindcss.com/) and integrates the
+Telegram Web Apps script. Open `index.html` in a browser (or within Telegram as a
+mini‑app) to try it out.

--- a/index.html
+++ b/index.html
@@ -3,45 +3,67 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Pinbax Fun</title>
-  <link href="https://fonts.googleapis.com/css2?family=Lobster&display=swap" rel="stylesheet">
+  <title>Telegram Mini App</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-  <style>
-    .font-logo { font-family: 'Lobster', cursive; }
-  </style>
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
 </head>
-<body class="bg-gradient-to-b from-purple-400 to-pink-300 min-h-screen flex flex-col">
-  <header class="text-center py-12">
-    <h1 class="text-white text-6xl font-logo">Pinbax</h1>
-    <p class="text-white text-lg mt-4">Весёлые моменты каждый день</p>
-    <div class="mt-6 space-x-4">
-      <a href="#" class="bg-white text-purple-600 px-6 py-2 rounded shadow">Начать</a>
-      <a href="#features" class="bg-purple-600 text-white px-6 py-2 rounded shadow">Узнать больше</a>
-    </div>
-  </header>
+<body class="h-screen flex flex-col bg-gray-100">
+  <div id="pages" class="flex-grow overflow-auto">
+    <section id="leaderboard" class="page hidden p-4">
+      <h2 class="text-2xl font-bold mb-4">Лидерборд</h2>
+      <p>Здесь будет таблица лидеров.</p>
+    </section>
+    <section id="task" class="page hidden p-4">
+      <h2 class="text-2xl font-bold mb-4">Задание</h2>
+      <p>Описание текущего задания.</p>
+    </section>
+    <section id="home" class="page p-4">
+      <h2 class="text-2xl font-bold mb-4">Главная</h2>
+      <p>Добро пожаловать в мини‑приложение!</p>
+    </section>
+    <section id="collections" class="page hidden p-4">
+      <h2 class="text-2xl font-bold mb-4">Мои коллекции</h2>
+      <p>Ваши собранные предметы.</p>
+    </section>
+    <section id="settings" class="page hidden p-4">
+      <h2 class="text-2xl font-bold mb-4">Настройки</h2>
+      <p>Параметры приложения.</p>
+    </section>
+  </div>
 
-  <main id="features" class="flex-grow bg-white py-12">
-    <div class="max-w-4xl mx-auto px-4 text-center">
-      <h2 class="text-3xl font-logo mb-8 text-purple-700">Почему Pinbax?</h2>
-      <div class="grid md:grid-cols-3 gap-8">
-        <div>
-          <h3 class="text-xl font-semibold mb-2">Просто</h3>
-          <p>Лёгкий старт без лишних настроек.</p>
-        </div>
-        <div>
-          <h3 class="text-xl font-semibold mb-2">Быстро</h3>
-          <p>Сервис оптимизирован для мгновенной загрузки.</p>
-        </div>
-        <div>
-          <h3 class="text-xl font-semibold mb-2">Весело</h3>
-          <p>Используйте Pinbax, чтобы делиться лучшими моментами.</p>
-        </div>
-      </div>
-    </div>
-  </main>
+  <nav class="fixed bottom-0 left-0 right-0 bg-white border-t flex text-center text-sm">
+    <button data-page="leaderboard" class="nav-btn flex-1 py-3">Лидерборд</button>
+    <button data-page="task" class="nav-btn flex-1 py-3">Задание</button>
+    <button data-page="home" class="nav-btn flex-1 py-3">Главная</button>
+    <button data-page="collections" class="nav-btn flex-1 py-3">Мои коллекции</button>
+    <button data-page="settings" class="nav-btn flex-1 py-3">Настройки</button>
+  </nav>
 
-  <footer class="bg-purple-600 text-white text-center py-6">
-    <p>&copy; 2025 Pinbax.fun</p>
-  </footer>
+  <script>
+    const pages = document.querySelectorAll('.page');
+    const buttons = document.querySelectorAll('.nav-btn');
+
+    function showPage(id) {
+      pages.forEach(p => p.classList.add('hidden'));
+      document.getElementById(id).classList.remove('hidden');
+      buttons.forEach(btn => {
+        if (btn.dataset.page === id) {
+          btn.classList.add('bg-blue-500', 'text-white');
+        } else {
+          btn.classList.remove('bg-blue-500', 'text-white');
+        }
+      });
+    }
+
+    buttons.forEach(btn => {
+      btn.addEventListener('click', () => showPage(btn.dataset.page));
+    });
+
+    if (window.Telegram?.WebApp) {
+      Telegram.WebApp.ready();
+    }
+
+    showPage('home');
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace page with a simple Telegram mini-app layout
- add five pages that are switched using a bottom navigation bar
- update README

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_684cb95417ac832eb84b1f41583d6544