### PR TITLE
Add theme switcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,14 +8,35 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
   <style>
-    body { background-color: #0b0b0b; }
-    .page { background-color: #1a1a1a; }
+    :root {
+      --bg-color: #0b0b0b;
+      --page-bg-color: #1a1a1a;
+      --text-color: #ffffff;
+      --nav-bg-color: #2d3748; /* gray-800 */
+      --nav-border-color: #4a5568; /* gray-700 */
+      --nav-text-color: #9ca3af; /* gray-400 */
+      --active-color: #39ff14;
+    }
+
+    body.light {
+      --bg-color: #ffffff;
+      --page-bg-color: #f3f4f6; /* gray-100 */
+      --text-color: #000000;
+      --nav-bg-color: #f9fafb; /* gray-50 */
+      --nav-border-color: #e5e7eb; /* gray-200 */
+      --nav-text-color: #6b7280; /* gray-500 */
+      --active-color: #008000;
+    }
+
+    body { background-color: var(--bg-color); color: var(--text-color); }
+    .page { background-color: var(--page-bg-color); }
+    nav { background-color: var(--nav-bg-color); border-color: var(--nav-border-color); color: var(--nav-text-color); }
     .nav-btn .icon { transition: transform 0.3s; }
     .nav-btn.active .icon { transform: scale(1.25); }
-    .nav-btn.active { color: #39ff14; }
+    .nav-btn.active { color: var(--active-color); }
   </style>
 </head>
-<body class="h-screen flex flex-col text-white">
+<body class="h-screen flex flex-col">
 
   <div id="pages" class="flex-grow relative overflow-hidden" style="touch-action: pan-y">
     <div id="pages-wrapper" class="flex h-full transition-transform duration-300" style="transform: translateX(-200%)">
@@ -38,12 +59,18 @@
       </section>
       <section id="settings" class="page w-full h-full flex-shrink-0 overflow-auto p-4">
         <h2 class="text-2xl font-bold mb-4">Настройки</h2>
-        <p>Параметры приложения.</p>
+        <div class="mb-4 flex items-center">
+          <span class="mr-2">Темная тема</span>
+          <label class="relative inline-flex items-center cursor-pointer">
+            <input type="checkbox" id="theme-toggle" class="sr-only peer">
+            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full peer-checked:after:border-white"></div>
+          </label>
+        </div>
       </section>
     </div>
   </div>
 
-  <nav class="fixed bottom-0 left-0 right-0 bg-gray-800 border-t border-gray-700 flex text-center text-sm text-gray-400">
+  <nav class="fixed bottom-0 left-0 right-0 border-t flex text-center text-sm transition-colors">
     <button data-page="leaderboard" class="nav-btn flex-1 py-3 flex flex-col items-center rounded">
       <i class="fas fa-trophy icon text-xl mb-1"></i>
       <span>Лидерборд</span>
@@ -69,6 +96,7 @@
   <script>
     const wrapper = document.getElementById('pages-wrapper');
     const buttons = document.querySelectorAll('.nav-btn');
+    const themeToggle = document.getElementById('theme-toggle');
 
     const pageOrder = ['leaderboard', 'task', 'home', 'collections', 'settings'];
     let currentIndex = pageOrder.indexOf('home');
@@ -91,6 +119,22 @@
 
     buttons.forEach(btn => {
       btn.addEventListener('click', () => showPage(btn.dataset.page));
+    });
+
+    function applyTheme(theme) {
+      document.body.classList.toggle('light', theme === 'light');
+    }
+
+    function initTheme() {
+      const saved = localStorage.getItem('theme') || 'dark';
+      applyTheme(saved);
+      themeToggle.checked = saved === 'dark';
+    }
+
+    themeToggle.addEventListener('change', () => {
+      const theme = themeToggle.checked ? 'dark' : 'light';
+      applyTheme(theme);
+      localStorage.setItem('theme', theme);
     });
 
     const container = document.getElementById('pages');
@@ -120,6 +164,7 @@
       Telegram.WebApp.expand();
     }
 
+    initTheme();
     showPage('home');
   </script>
 </body>


### PR DESCRIPTION
## Summary
- support light/dark themes via CSS variables
- add toggle switch in settings page
- remember user preference in localStorage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d728a0f88832e83a017f02ba1b446