### PR TITLE
Load assets from jsDelivr CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ within Telegram as a mini‑app) to try it out. На мобильных устр
 
 ## External assets
 
-The main stylesheet is now `style.css` and the main script is `script.js`. To serve them via a CDN, host these files on a service such as jsDelivr or GitHub Pages and update the paths in `index.html` accordingly.
+The main stylesheet is now `style.css` and the main script is `script.js`. To serve them via a CDN, host these files on a service such as jsDelivr or GitHub Pages and update the paths in `index.html` accordingly. This demo loads both files from GitHub via jsDelivr using `https://cdn.jsdelivr.net/gh/LBoy2006/fletapp1@main/<file>`. Replace `@main` with a specific tag to pin to a release if desired.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,10 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet" />
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
-  <link rel="stylesheet" href="style.css" />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/LBoy2006/fletapp1@main/style.css"
+  />
 </head>
 <body class="h-screen flex flex-col">
   <div id="pages" class="flex-grow relative overflow-hidden" style="touch-action: pan-y">
@@ -72,6 +75,6 @@
     </button>
    </nav>
 
-  <script src="script.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/LBoy2006/fletapp1@main/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update index.html to point jsDelivr URLs at this repo
- clarify README with example jsDelivr URL

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684e00e91a78832e98c3d436a2f99f00