### PR TITLE
Add language switcher and localize buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,25 +16,25 @@
   <div id="pages" class="flex-grow relative overflow-hidden" style="touch-action: pan-y">
     <div id="pages-wrapper" class="flex h-full transition-transform duration-300" style="transform: translateX(-200%)">
       <section id="leaderboard" class="page w-full h-full flex-shrink-0 overflow-auto p-4">
-        <h2 class="text-2xl font-bold mb-4">Лидерборд</h2>
+        <h2 id="leaderboard-title" class="text-2xl font-bold mb-4">Лидерборд</h2>
         <p>Здесь будет таблица лидеров.</p>
       </section>
       <section id="task" class="page w-full h-full flex-shrink-0 overflow-auto p-4">
-        <h2 class="text-2xl font-bold mb-4">Задание</h2>
+        <h2 id="task-title" class="text-2xl font-bold mb-4">Задание</h2>
         <p>Описание текущего задания.</p>
       </section>
       <section id="home" class="page w-full h-full flex-shrink-0 overflow-auto p-4">
-        <h2 class="text-2xl font-bold mb-4">Главная</h2>
+        <h2 id="home-title" class="text-2xl font-bold mb-4">Главная</h2>
         <p>Привет, Севастополь!</p>
       </section>
       <section id="collections" class="page w-full h-full flex-shrink-0 overflow-auto p-4">
-        <h2 class="text-2xl font-bold mb-4">Рюкзак</h2>
+        <h2 id="collections-title" class="text-2xl font-bold mb-4">Рюкзак</h2>
         <p>Ваши собранные предметы.</p>
       </section>
       <section id="settings" class="page w-full h-full flex-shrink-0 overflow-auto p-4">
-        <h2 class="text-2xl font-bold mb-4">Настройки</h2>
+        <h2 id="settings-title" class="text-2xl font-bold mb-4">Настройки</h2>
         <div class="mb-4 flex items-center">
-          <span class="mr-2">Темная тема</span>
+          <span id="theme-label" class="mr-2">Темная тема</span>
          <label class="relative inline-flex items-center cursor-pointer">
            <input type="checkbox" id="theme-toggle" class="sr-only peer">
            <div class="w-11 h-6 bg-gray-300 rounded-full transition-colors duration-300 peer-checked:bg-blue-600 before:content-[''] before:absolute before:top-0.5 before:left-0.5 before:w-5 before:h-5 before:bg-white before:border before:border-gray-300 before:rounded-full before:transition-transform before:duration-300 peer-checked:before:translate-x-full"></div>
@@ -42,11 +42,18 @@
 
         </div>
         <div class="mb-4 flex items-center">
-          <span class="mr-2">Полноэкранный режим</span>
+          <span id="fullscreen-label" class="mr-2">Полноэкранный режим</span>
           <label class="relative inline-flex items-center cursor-pointer">
             <input type="checkbox" id="fullscreen-toggle" class="sr-only peer">
             <div class="w-11 h-6 bg-gray-300 rounded-full transition-colors duration-300 peer-checked:bg-blue-600 before:content-[''] before:absolute before:top-0.5 before:left-0.5 before:w-5 before:h-5 before:bg-white before:border before:border-gray-300 before:rounded-full before:transition-transform before:duration-300 peer-checked:before:translate-x-full"></div>
           </label>
+        </div>
+        <div class="mb-4 flex items-center">
+          <span id="language-label" class="mr-2">Язык</span>
+          <select id="language-select" class="border rounded p-1">
+            <option value="ru">Русский</option>
+            <option value="en">English</option>
+          </select>
         </div>
       </section>
     </div>
@@ -55,23 +62,23 @@
   <nav class="fixed bottom-0 left-0 right-0 border-t flex text-center text-sm transition-colors">
     <button data-page="leaderboard" class="nav-btn flex-1 py-3 flex flex-col items-center rounded">
       <i class="fas fa-trophy icon text-xl mb-1"></i>
-      <span>Лидерборд</span>
+      <span id="nav-leaderboard">Лидерборд</span>
     </button>
     <button data-page="task" class="nav-btn flex-1 py-3 flex flex-col items-center rounded">
       <i class="fas fa-clipboard-list icon text-xl mb-1"></i>
-      <span>Задание</span>
+      <span id="nav-task">Задание</span>
     </button>
     <button data-page="home" class="nav-btn flex-1 py-3 flex flex-col items-center rounded">
       <i class="fas fa-home icon text-xl mb-1"></i>
-      <span>Главная</span>
+      <span id="nav-home">Главная</span>
     </button>
     <button data-page="collections" class="nav-btn flex-1 py-3 flex flex-col items-center rounded">
       <i class="fas fa-boxes icon text-xl mb-1"></i>
-      <span>Рюкзак</span>
+      <span id="nav-collections">Рюкзак</span>
     </button>
     <button data-page="settings" class="nav-btn flex-1 py-3 flex flex-col items-center rounded">
       <i class="fas fa-cog icon text-xl mb-1"></i>
-      <span>Настройки</span>
+      <span id="nav-settings">Настройки</span>
     </button>
    </nav>
 

--- a/script.js
+++ b/script.js
@@ -2,6 +2,30 @@ const wrapper = document.getElementById('pages-wrapper');
 const buttons = document.querySelectorAll('.nav-btn');
 const themeToggle = document.getElementById('theme-toggle');
 const fullscreenToggle = document.getElementById('fullscreen-toggle');
+const languageSelect = document.getElementById('language-select');
+
+const translations = {
+  ru: {
+    leaderboard: 'Лидерборд',
+    task: 'Задание',
+    home: 'Главная',
+    collections: 'Рюкзак',
+    settings: 'Настройки',
+    theme: 'Темная тема',
+    fullscreen: 'Полноэкранный режим',
+    language: 'Язык'
+  },
+  en: {
+    leaderboard: 'Leaderboard',
+    task: 'Task',
+    home: 'Home',
+    collections: 'Backpack',
+    settings: 'Settings',
+    theme: 'Dark theme',
+    fullscreen: 'Fullscreen mode',
+    language: 'Language'
+  }
+};
 const pageOrder = ['leaderboard', 'task', 'home', 'collections', 'settings'];
 let currentIndex = pageOrder.indexOf('home');
 
@@ -19,6 +43,30 @@ function showPage(id) {
 
 function applyTheme(theme) {
   document.body.classList.toggle('light', theme === 'light');
+}
+
+function applyTranslations(lang) {
+  const t = translations[lang] || translations.ru;
+  document.documentElement.lang = lang;
+  document.getElementById('leaderboard-title').textContent = t.leaderboard;
+  document.getElementById('task-title').textContent = t.task;
+  document.getElementById('home-title').textContent = t.home;
+  document.getElementById('collections-title').textContent = t.collections;
+  document.getElementById('settings-title').textContent = t.settings;
+  document.getElementById('theme-label').textContent = t.theme;
+  document.getElementById('fullscreen-label').textContent = t.fullscreen;
+  document.getElementById('language-label').textContent = t.language;
+  document.getElementById('nav-leaderboard').textContent = t.leaderboard;
+  document.getElementById('nav-task').textContent = t.task;
+  document.getElementById('nav-home').textContent = t.home;
+  document.getElementById('nav-collections').textContent = t.collections;
+  document.getElementById('nav-settings').textContent = t.settings;
+  languageSelect.value = lang;
+}
+
+function initLanguage() {
+  const saved = localStorage.getItem('lang') || 'ru';
+  applyTranslations(saved);
 }
 
 function initTheme() {
@@ -58,6 +106,7 @@ if (window.Telegram?.WebApp) {
 
   initTheme();
   initFullscreen();
+  initLanguage();
   applySafeInsets();
   showPage('home');
 
@@ -80,6 +129,12 @@ themeToggle.addEventListener('change', () => {
   const theme = themeToggle.checked ? 'dark' : 'light';
   applyTheme(theme);
   localStorage.setItem('theme', theme);
+});
+
+languageSelect.addEventListener('change', () => {
+  const lang = languageSelect.value;
+  applyTranslations(lang);
+  localStorage.setItem('lang', lang);
 });
 
 // свайпы


### PR DESCRIPTION
## Summary
- add language select control in settings
- localize page titles and navigation button labels
- store chosen language in localStorage

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e04698b88832ead55320156404daf