### PR TITLE
Align headers and settings toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,34 +19,34 @@
   <div id="pages" class="flex-grow relative overflow-hidden" style="touch-action: pan-y">
     <div id="pages-wrapper" class="flex h-full transition-transform duration-300" style="transform: translateX(-200%)">
       <section id="leaderboard" class="page w-full h-full flex-shrink-0 overflow-auto p-4">
-        <h2 id="leaderboard-title" class="text-2xl font-bold mb-4">Лидерборд</h2>
+        <h2 id="leaderboard-title" class="text-2xl font-bold mb-4 text-center">Лидерборд</h2>
         <p>Здесь будет таблица лидеров.</p>
       </section>
       <section id="task" class="page w-full h-full flex-shrink-0 overflow-auto p-4">
-        <h2 id="task-title" class="text-2xl font-bold mb-4">Задание</h2>
+        <h2 id="task-title" class="text-2xl font-bold mb-4 text-center">Задание</h2>
         <p>Описание текущего задания.</p>
       </section>
       <section id="home" class="page w-full h-full flex-shrink-0 overflow-auto p-4">
-        <h2 id="home-title" class="text-2xl font-bold mb-4">Главная</h2>
+        <h2 id="home-title" class="text-2xl font-bold mb-4 text-center">Главная</h2>
         <p>Привет, Севастополь!</p>
       </section>
       <section id="collections" class="page w-full h-full flex-shrink-0 overflow-auto p-4">
-        <h2 id="collections-title" class="text-2xl font-bold mb-4">Рюкзак</h2>
+        <h2 id="collections-title" class="text-2xl font-bold mb-4 text-center">Рюкзак</h2>
         <p>Ваши собранные предметы.</p>
       </section>
       <section id="settings" class="page w-full h-full flex-shrink-0 overflow-auto p-4">
-        <h2 id="settings-title" class="text-2xl font-bold mb-4">Настройки</h2>
-        <div class="mb-4 flex items-center">
+        <h2 id="settings-title" class="text-2xl font-bold mb-4 text-center">Настройки</h2>
+        <div class="mb-4 flex items-center justify-between w-full">
           <span id="theme-label" class="mr-2">Темная тема</span>
-         <label class="relative inline-flex items-center cursor-pointer">
+         <label class="relative inline-flex items-center cursor-pointer ml-auto">
            <input type="checkbox" id="theme-toggle" class="sr-only peer">
            <div class="w-11 h-6 bg-gray-300 rounded-full transition-colors duration-300 peer-checked:bg-blue-600 before:content-[''] before:absolute before:top-0.5 before:left-0.5 before:w-5 before:h-5 before:bg-white before:border before:border-gray-300 before:rounded-full before:transition-transform before:duration-300 peer-checked:before:translate-x-full"></div>
          </label>
 
         </div>
-        <div class="mb-4 flex items-center">
+        <div class="mb-4 flex items-center justify-between w-full">
           <span id="fullscreen-label" class="mr-2">Полноэкранный режим</span>
-          <label class="relative inline-flex items-center cursor-pointer">
+          <label class="relative inline-flex items-center cursor-pointer ml-auto">
             <input type="checkbox" id="fullscreen-toggle" class="sr-only peer">
             <div class="w-11 h-6 bg-gray-300 rounded-full transition-colors duration-300 peer-checked:bg-blue-600 before:content-[''] before:absolute before:top-0.5 before:left-0.5 before:w-5 before:h-5 before:bg-white before:border before:border-gray-300 before:rounded-full before:transition-transform before:duration-300 peer-checked:before:translate-x-full"></div>
           </label>


### PR DESCRIPTION
## Summary
- center titles on all pages
- right-align toggle switches on the settings page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e1b0e8268832ea20ac372c5941a39