### PR TITLE
Fix Vue ref binding for pages container

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 
 <div id="app" class="h-full flex flex-col">
   <!-- Pages -->
-  <div ref="pages" class="flex-grow relative overflow-hidden" style="touch-action: pan-y">
+  <div ref="pagesRef" class="flex-grow relative overflow-hidden" style="touch-action: pan-y">
     <div
       class="flex h-full transition-transform duration-300"
       :style="{transform: `translateX(-${currentIndex.value * 100}%)`}"


### PR DESCRIPTION
## Summary
- fix `ref` attribute for pages container to use `pagesRef`

## Testing
- `node --check script_extract.js`

------
https://chatgpt.com/codex/tasks/task_e_6850a9773380832ebcacac4056f9fbcc