### PR TITLE
Ensure safe area re-applies on fullscreen

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,6 +202,9 @@ const Settings = {
           Telegram.WebApp.exitFullscreen();
           fullscreen.value = false;
         }
+        setTimeout(() => {
+          if (window.applySafeInsets) window.applySafeInsets();
+        }, 100);
       }
 
     function changeLang(e) {
@@ -321,6 +324,7 @@ createApp({
         });
       }
     }
+    window.applySafeInsets = applySafeInsets;
 
     onMounted(() => {
       if (window.Telegram?.WebApp) {


### PR DESCRIPTION
## Summary
- adjust safe insets after toggling fullscreen
- expose `applySafeInsets` globally so settings can trigger it

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850b12df2e0832ea0d72cafa442c684