### PR TITLE
Enable interactive swipe navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,8 +85,9 @@
   <!-- Pages -->
   <div ref="pagesRef" class="flex-grow relative overflow-hidden" style="touch-action: pan-y">
     <div
+      ref="innerRef"
       class="flex h-full transition-transform duration-300"
-      :style="{transform: `translateX(-${currentIndex * 100}%)`}"
+      :style="dragStyle"
     >
       <section
         v-for="(page, idx) in pageOrder"
@@ -365,9 +366,17 @@ createApp({
     const currentIndex = ref(pageOrder.indexOf('home'));
     const infoModal = ref(false);
     const pagesRef = ref(null);
+    const innerRef = ref(null);
     const navRef = ref(null);
     const showLabels = ref(false);
+    const dragOffset = ref(0);
+    const isDragging = ref(false);
     let hideTimer = null;
+
+    const dragStyle = computed(() => ({
+      transform: `translateX(calc(-${currentIndex.value * 100}% + ${dragOffset.value}%))`,
+      transition: isDragging.value ? 'none' : ''
+    }));
 
     // Изменение языка через событие
     function onLangChange(e) {
@@ -377,6 +386,8 @@ createApp({
 
     function showPage(page) {
       currentIndex.value = pageOrder.indexOf(page);
+      dragOffset.value = 0;
+      isDragging.value = false;
     }
     function showInfo() {
       infoModal.value = true;
@@ -391,19 +402,30 @@ createApp({
     let startX = null;
     onMounted(() => {
       const el = pagesRef.value;
+      const width = () => el.clientWidth;
       el.addEventListener('touchstart', e => {
-        if (e.touches.length === 1) startX = e.touches[0].clientX;
+        if (e.touches.length === 1) {
+          startX = e.touches[0].clientX;
+          isDragging.value = true;
+        }
+      });
+      el.addEventListener('touchmove', e => {
+        if (!isDragging.value || startX === null) return;
+        const deltaX = e.touches[0].clientX - startX;
+        dragOffset.value = (deltaX / width()) * 100;
       });
       el.addEventListener('touchend', e => {
-        if (startX === null) return;
+        if (!isDragging.value || startX === null) return;
         const deltaX = e.changedTouches[0].clientX - startX;
-        if (Math.abs(deltaX) > 50) {
+        if (Math.abs(deltaX) > width() / 4) {
           if (deltaX < 0 && currentIndex.value < pageOrder.length - 1) {
             showPage(pageOrder[currentIndex.value + 1]);
           } else if (deltaX > 0 && currentIndex.value > 0) {
             showPage(pageOrder[currentIndex.value - 1]);
           }
         }
+        dragOffset.value = 0;
+        isDragging.value = false;
         startX = null;
       });
     });
@@ -472,8 +494,10 @@ createApp({
       pageIcons,
       pages,
       pagesRef,
+      innerRef,
       navRef,
-      showLabels
+      showLabels,
+      dragStyle
     };
   }
 }).mount('#app');


### PR DESCRIPTION
## Summary
- add drag gesture tracking to page container
- include dragOffset and isDragging refs to control swipe animation
- compute dragStyle transform so pages follow the finger

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6850ead9e07c832e8d6d2354dce82000