### PR TITLE
Improve leaderboard and home UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,6 +190,7 @@ const Leaderboard = {
           avatar: avatars[Math.floor(Math.random() * avatars.length)]
         });
       }
+      arr.sort((a, b) => b.score - a.score);
       return arr;
     }
 
@@ -219,7 +220,8 @@ const Leaderboard = {
         </button>
       </div>
       <div class="flex-1 overflow-y-auto">
-        <ul>
+        <div class="border border-gray-700 rounded p-2">
+          <ul class="pb-20">
           <li
             v-for="(player, idx) in players"
             :key="idx"
@@ -230,7 +232,8 @@ const Leaderboard = {
             <span class="flex-1">{{ player.name }}</span>
             <span class="font-semibold">{{ player.score }}</span>
           </li>
-        </ul>
+          </ul>
+        </div>
       </div>
     </div>
   `
@@ -255,7 +258,7 @@ const Home = {
     return { user, progress };
   },
   template: `<div>
-    <div class="flex items-center bg-gray-800 p-3 rounded mb-4">
+    <div class="flex items-center bg-gray-600 p-3 rounded mb-4">
       <img :src="user.photo_url || 'assets/icon.png'" class="w-12 h-12 rounded-full mr-3" />
       <div class="flex-1">
         <div class="font-semibold">{{ user.username || user.first_name || 'User' }}</div>
@@ -264,7 +267,6 @@ const Home = {
         </div>
       </div>
     </div>
-    <h2 class="text-2xl font-bold mb-4 text-center">{{ t.home }}</h2>
     <p>Привет, Севастополь!</p>
     <button @click="showInfo()" class="mt-4 px-4 py-2 bg-blue-500 text-white rounded">Инфо</button>
   </div>`


### PR DESCRIPTION
## Summary
- update player generator to sort by high score
- wrap leaderboard list with a bordered container
- lighten the user info block on the home page
- drop the "Главная" heading

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68514aede3a8832e9aa6581699ae39b7