### PR TITLE
Remove greeting and adjust leaderboard padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,8 +220,8 @@ const Leaderboard = {
         </button>
       </div>
       <div class="flex-1 overflow-y-auto">
-        <div class="border border-gray-700 rounded p-2">
-          <ul class="pb-20">
+        <div class="border border-gray-700 rounded p-2 mb-20">
+          <ul>
           <li
             v-for="(player, idx) in players"
             :key="idx"
@@ -267,7 +267,6 @@ const Home = {
         </div>
       </div>
     </div>
-    <p>Привет, Севастополь!</p>
     <button @click="showInfo()" class="mt-4 px-4 py-2 bg-blue-500 text-white rounded">Инфо</button>
   </div>`
 };


### PR DESCRIPTION
## Summary
- remove greeting text from home page
- add bottom margin to leaderboard container so frame doesn't overlap the nav bar

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68514f590280832e882624adb7e600bd