### PR TITLE
Improve swipe gesture threshold

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,24 +402,35 @@ createApp({
 
     // Свайпы страниц
     let startX = null;
+    let startY = null;
+    const dragThreshold = 20; // Минимальное смещение в пикселях для начала свайпа
     onMounted(() => {
       const el = pagesRef.value;
       const width = () => el.clientWidth;
       el.addEventListener('touchstart', e => {
         if (e.touches.length === 1) {
           startX = e.touches[0].clientX;
-          isDragging.value = true;
+          startY = e.touches[0].clientY;
+          isDragging.value = false;
         }
       });
       el.addEventListener('touchmove', e => {
-        if (!isDragging.value || startX === null) return;
+        if (startX === null) return;
         const deltaX = e.touches[0].clientX - startX;
+        const deltaY = e.touches[0].clientY - startY;
+        if (!isDragging.value) {
+          if (Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) > dragThreshold) {
+            isDragging.value = true;
+          } else {
+            return;
+          }
+        }
         dragOffset.value = (deltaX / width()) * 100;
       });
       el.addEventListener('touchend', e => {
-        if (!isDragging.value || startX === null) return;
+        if (startX === null) return;
         const deltaX = e.changedTouches[0].clientX - startX;
-        if (Math.abs(deltaX) > width() / 4) {
+        if (isDragging.value && Math.abs(deltaX) > width() / 4) {
           if (deltaX < 0 && currentIndex.value < pageOrder.length - 1) {
             showPage(pageOrder[currentIndex.value + 1]);
           } else if (deltaX > 0 && currentIndex.value > 0) {
@@ -429,6 +440,7 @@ createApp({
         dragOffset.value = 0;
         isDragging.value = false;
         startX = null;
+        startY = null;
       });
     });
 


### PR DESCRIPTION
## Summary
- prevent accidental swipes by adding a small threshold before drag starts

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685158d21ac4832e897ca3244bd8ef82