### PR TITLE
Update leaderboard view with user ranking

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
 </div>
 
 <script type="module">
-const { createApp, ref, computed, onMounted, watch } = Vue;
+const { createApp, ref, computed, onMounted, watch, reactive } = Vue;
 
 const translations = {
   ru: {
@@ -137,6 +137,7 @@ const translations = {
     theme: 'Темная тема',
     fullscreen: 'Полноэкранный режим',
     language: 'Язык',
+    points: 'Очки',
     overall: 'Общий',
     monthly: 'Месячный',
     daily: 'Дневной'
@@ -150,6 +151,7 @@ const translations = {
     theme: 'Dark theme',
     fullscreen: 'Fullscreen mode',
     language: 'Language',
+    points: 'Points',
     overall: 'Overall',
     monthly: 'Monthly',
     daily: 'Daily'
@@ -165,6 +167,7 @@ const pageIcons = {
   settings: "fas fa-cog"
 };
 
+const userData = reactive({ user: {}, score: Math.floor(Math.random() * 1000), rank: 0 });
 // ===== Страницы (Компоненты) ======
 const Leaderboard = {
   props: ['t'],
@@ -190,7 +193,14 @@ const Leaderboard = {
           avatar: avatars[Math.floor(Math.random() * avatars.length)]
         });
       }
+      arr.push({
+        name: userData.user.username || userData.user.first_name || 'You',
+        score: userData.score,
+        avatar: userData.user.photo_url || 'assets/icon.png',
+        isUser: true
+      });
       arr.sort((a, b) => b.score - a.score);
+      userData.rank = arr.findIndex(p => p.isUser) + 1;
       return arr;
     }
 
@@ -203,7 +213,7 @@ const Leaderboard = {
       players.value = randomPlayers();
     });
 
-    return { tab, tabs, players, setTab };
+    return { tab, tabs, players, setTab, userData };
   },
   template: `
     <div class="flex flex-col h-full">
@@ -223,7 +233,7 @@ const Leaderboard = {
         <div class="border border-gray-700 rounded p-2 mb-20">
           <ul>
           <li
-            v-for="(player, idx) in players"
+            v-for="(player, idx) in players.slice(0, 10)"
             :key="idx"
             class="flex items-center py-2 border-b border-gray-700"
           >
@@ -233,6 +243,12 @@ const Leaderboard = {
             <span class="font-semibold">{{ player.score }}</span>
           </li>
           </ul>
+          <div class="flex items-center py-2 border-t border-gray-700 mt-2">
+            <span class="w-6 text-right mr-2">{{ userData.rank }}</span>
+            <img :src="userData.user.photo_url || 'assets/icon.png'" class="w-10 h-10 rounded-full mr-3" />
+            <span class="flex-1">{{ userData.user.username || userData.user.first_name || 'You' }}</span>
+            <span class="font-semibold">{{ userData.score }}</span>
+          </div>
         </div>
       </div>
     </div>
@@ -252,16 +268,18 @@ const Home = {
     const progress = ref(Math.floor(Math.random() * 100));
     onMounted(() => {
       if (window.Telegram?.WebApp?.initDataUnsafe?.user) {
-        user.value = Telegram.WebApp.initDataUnsafe.user;
+        userData.user = Telegram.WebApp.initDataUnsafe.user;
+        user.value = userData.user;
       }
     });
-    return { user, progress };
+    return { user, progress, userData };
   },
   template: `<div>
     <div class="flex items-center bg-gray-600 p-3 rounded mb-4">
       <img :src="user.photo_url || 'assets/icon.png'" class="w-12 h-12 rounded-full mr-3" />
       <div class="flex-1">
         <div class="font-semibold">{{ user.username || user.first_name || 'User' }}</div>
+        <div class="text-sm">{{ t.points }}: {{ userData.score }}</div>
         <div class="w-full bg-gray-700 rounded h-2 mt-1">
           <div class="bg-green-500 h-2 rounded" :style="{ width: progress + '%' }"></div>
         </div>


### PR DESCRIPTION
## Summary
- limit leaderboard display to top 10 players
- show the current user's rank and score
- display user's score on the home page
- add translations for "points"

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68515e141070832e98196841d09b9374