### PR TITLE
Fix leaderboard frame layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,9 +230,9 @@ const Leaderboard = {
           {{ t[key] }}
         </button>
       </div>
-      <div class="flex-1 overflow-y-auto">
-        <div class="border border-gray-700 rounded p-2 mb-20">
-          <ul>
+      <div class="flex-1 flex flex-col">
+        <div class="border border-gray-700 rounded p-2 mb-4 flex flex-col h-full">
+          <ul class="flex-1 overflow-y-auto">
           <li
             v-for="(player, idx) in players.slice(0, 10)"
             :key="idx"


### PR DESCRIPTION
## Summary
- keep leaderboard frame above nav bar
- scroll leaderboard entries inside the frame

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68516b0063c0832ea9ebdc2e0c234f61