### PR TITLE
Move translations to dedicated module

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -49,39 +49,8 @@ import Suppliers from './components/Suppliers.vue';
 import Affiliate from './components/Affiliate.vue';
 import Profile from './components/Profile.vue';
 import { userData } from './state';
+import { translations } from './translations.js';
 
-const translations = {
-  ru: {
-    feed: 'Лента',
-    finds: 'Новинки',
-    suppliers: 'Поставщики',
-    affiliate: 'Партнерка',
-    profile: 'Профиль',
-    feedInDev: 'Лента находится в разработке',
-    theme: 'Темная тема',
-    fullscreen: 'Полноэкранный режим',
-    language: 'Язык',
-    points: 'Очки',
-    overall: 'Общий',
-    monthly: 'Месячный',
-    daily: 'Дневной'
-  },
-  en: {
-    feed: 'Feed',
-    finds: 'Finds',
-    suppliers: 'Suppliers',
-    affiliate: 'Affiliate',
-    profile: 'Profile',
-    feedInDev: 'Feed is under development',
-    theme: 'Dark theme',
-    fullscreen: 'Fullscreen mode',
-    language: 'Language',
-    points: 'Points',
-    overall: 'Overall',
-    monthly: 'Monthly',
-    daily: 'Daily'
-  }
-};
 
 const navItems = ['feed', 'finds', 'suppliers', 'affiliate', 'profile'];
 const pageOrder = ['finds', 'suppliers', 'affiliate', 'profile'];

--- a/src/translations.js
+++ b/src/translations.js
@@ -1,0 +1,33 @@
+export const translations = {
+  ru: {
+    feed: 'Лента',
+    finds: 'Новинки',
+    suppliers: 'Поставщики',
+    affiliate: 'Партнерка',
+    profile: 'Профиль',
+    feedInDev: 'Лента находится в разработке',
+    theme: 'Темная тема',
+    fullscreen: 'Полноэкранный режим',
+    language: 'Язык',
+    points: 'Очки',
+    overall: 'Общий',
+    monthly: 'Месячный',
+    daily: 'Дневной'
+  },
+  en: {
+    feed: 'Feed',
+    finds: 'Finds',
+    suppliers: 'Suppliers',
+    affiliate: 'Affiliate',
+    profile: 'Profile',
+    feedInDev: 'Feed is under development',
+    theme: 'Dark theme',
+    fullscreen: 'Fullscreen mode',
+    language: 'Language',
+    points: 'Points',
+    overall: 'Overall',
+    monthly: 'Monthly',
+    daily: 'Daily'
+  }
+};
+


### PR DESCRIPTION
## Summary
- extract translation strings from `App.vue`
- create a new `translations.js` module and import it

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685341f8a404832eaecf5a3b88ca5696