### PR TITLE
Implement supplier catalog with filters

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -69,3 +69,67 @@ def request_withdraw(user_id: int, db: Session = Depends(get_db)):
     db.commit()
     db.refresh(stat)
     return stat
+
+
+@app.get('/suppliers/categories1')
+def get_categories1(db: Session = Depends(get_db)):
+    cats = db.query(models.Supplier.category1).distinct().all()
+    return [c[0] for c in cats if c[0]]
+
+
+@app.get('/suppliers/categories2')
+def get_categories2(categories1: str = '', db: Session = Depends(get_db)):
+    q = db.query(models.Supplier.category2)
+    if categories1:
+        cats1 = [c.strip() for c in categories1.split(',') if c.strip()]
+        q = q.filter(models.Supplier.category1.in_(cats1))
+    cats = q.distinct().all()
+    return [c[0] for c in cats if c[0]]
+
+
+@app.get('/suppliers', response_model=list[schemas.SupplierOut])
+def list_suppliers(user_id: int, categories1: str = '', categories2: str = '', favorites_only: bool = False, db: Session = Depends(get_db)):
+    q = db.query(models.Supplier)
+    if categories1:
+        cats1 = [c.strip() for c in categories1.split(',') if c.strip()]
+        q = q.filter(models.Supplier.category1.in_(cats1))
+    if categories2:
+        cats2 = [c.strip() for c in categories2.split(',') if c.strip()]
+        q = q.filter(models.Supplier.category2.in_(cats2))
+    suppliers = q.all()
+    fav_ids = set(
+        r.supplier_id for r in db.query(models.FavoriteSupplier).filter(models.FavoriteSupplier.user_id == user_id)
+    )
+    if favorites_only:
+        suppliers = [s for s in suppliers if s.id in fav_ids]
+    result = []
+    for s in suppliers:
+        item = schemas.SupplierOut.from_orm(s)
+        item.is_favorite = s.id in fav_ids
+        result.append(item)
+    return result
+
+
+@app.get('/suppliers/{supplier_id}/contacts', response_model=schemas.SupplierContacts)
+def get_supplier_contacts(supplier_id: int, db: Session = Depends(get_db)):
+    s = db.query(models.Supplier).filter(models.Supplier.id == supplier_id).first()
+    if not s:
+        raise HTTPException(status_code=404, detail='Supplier not found')
+    return schemas.SupplierContacts.from_orm(s)
+
+
+@app.post('/suppliers/{supplier_id}/favorite')
+def toggle_favorite(supplier_id: int, data: dict, db: Session = Depends(get_db)):
+    user_id = data.get('user_id')
+    if not user_id:
+        raise HTTPException(status_code=400, detail='user_id required')
+    fav = db.query(models.FavoriteSupplier).filter(models.FavoriteSupplier.user_id == user_id, models.FavoriteSupplier.supplier_id == supplier_id).first()
+    if fav:
+        db.delete(fav)
+        db.commit()
+        return {'favorite': False}
+    else:
+        fav = models.FavoriteSupplier(user_id=user_id, supplier_id=supplier_id)
+        db.add(fav)
+        db.commit()
+        return {'favorite': True}

--- a/backend/models.py
+++ b/backend/models.py
@@ -23,3 +23,23 @@ class Affiliate(Base):
     referral_link = Column(String)
     materials_link = Column(String)
     withdraw_requested = Column(Boolean, default=False)
+
+
+class Supplier(Base):
+    __tablename__ = 'suppliers'
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String)
+    description = Column(String)
+    photo_url = Column(String)
+    category1 = Column(String)
+    category2 = Column(String)
+    contact_link = Column(String)
+    contact_phone = Column(String)
+    contact_password = Column(String)
+
+
+class FavoriteSupplier(Base):
+    __tablename__ = 'favorite_suppliers'
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, index=True)
+    supplier_id = Column(Integer, index=True)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -37,3 +37,28 @@ class AffiliateOut(AffiliateBase):
 
     class Config:
         from_attributes = True
+
+
+class SupplierBase(BaseModel):
+    name: str
+    description: str | None = None
+    photo_url: str | None = None
+    category1: str | None = None
+    category2: str | None = None
+
+
+class SupplierOut(SupplierBase):
+    id: int
+    is_favorite: bool | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class SupplierContacts(BaseModel):
+    contact_link: str | None = None
+    contact_phone: str | None = None
+    contact_password: str | None = None
+
+    class Config:
+        from_attributes = True

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,6 +1,6 @@
 from datetime import date
 from .database import engine, SessionLocal
-from .models import User, Affiliate, Base
+from .models import User, Affiliate, Supplier, Base
 
 Base.metadata.create_all(bind=engine)
 
@@ -25,6 +25,31 @@ def seed():
             materials_link='https://drive.google.com/folder'
         )
         db.add(stat)
+        db.commit()
+    if not db.query(Supplier).first():
+        suppliers = [
+            Supplier(
+                name='Store A',
+                description='Надежный поставщик техники',
+                photo_url='https://via.placeholder.com/100',
+                category1='техника',
+                category2='Apple',
+                contact_link='https://example.com',
+                contact_phone='+1 111 111',
+                contact_password='1234'
+            ),
+            Supplier(
+                name='Fashion B',
+                description='Модная одежда',
+                photo_url='https://via.placeholder.com/100',
+                category1='одежда',
+                category2='LV',
+                contact_link='https://example.com',
+                contact_phone='+1 222 222',
+                contact_password='abcd'
+            )
+        ]
+        db.add_all(suppliers)
         db.commit()
     db.close()
 

--- a/src/components/Suppliers.vue
+++ b/src/components/Suppliers.vue
@@ -1,10 +1,161 @@
 <template>
-  <div>
-    <h2 class="text-2xl font-bold mb-4 text-center">{{ t.suppliers }}</h2>
-    <p>Список поставщиков.</p>
+  <div class="space-y-4 p-4">
+    <h2 class="text-2xl font-bold text-center">Поставщики</h2>
+
+    <div class="space-y-3">
+      <div>
+        <div class="text-sm mb-1">Категория</div>
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="c in categories1"
+            :key="c"
+            @click="toggleCat1(c)"
+            :class="['px-3 py-1 rounded-full text-sm border', selectedCat1.includes(c) ? 'bg-blue-600 text-white' : 'bg-gray-700']"
+          >{{ c }}</button>
+        </div>
+        <div v-if="!categories1.length" class="text-gray-500 text-sm">—</div>
+      </div>
+
+      <div>
+        <div class="text-sm mb-1">Бренд</div>
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="b in categories2"
+            :key="b"
+            @click="toggleCat2(b)"
+            :class="['px-3 py-1 rounded-full text-sm border', selectedCat2.includes(b) ? 'bg-blue-600 text-white' : 'bg-gray-700']"
+          >{{ b }}</button>
+        </div>
+        <div v-if="!categories2.length" class="text-gray-500 text-sm">—</div>
+      </div>
+
+      <div class="flex items-center">
+        <input id="favOnly" type="checkbox" v-model="showFavOnly" class="mr-2" />
+        <label for="favOnly" class="text-sm">Показать только избранное</label>
+      </div>
+    </div>
+
+    <div v-if="!suppliers.length" class="text-center text-gray-500 py-10">Нет результатов</div>
+    <div v-else class="space-y-4">
+      <div v-for="s in suppliers" :key="s.id" class="bg-gray-800 p-4 rounded flex items-center">
+        <img :src="s.photo_url" class="w-12 h-12 rounded-full object-cover mr-3" />
+        <div class="flex-1">
+          <div class="font-semibold">{{ s.name }}</div>
+          <div class="text-sm text-gray-400">{{ s.description }}</div>
+        </div>
+        <button @click="toggleFavorite(s)" class="text-xl mr-3">
+          <i :class="['fas', s.is_favorite ? 'fa-heart text-red-500' : 'fa-heart']"></i>
+        </button>
+        <button @click="openContacts(s)" class="bg-blue-600 text-white px-3 py-1 rounded text-sm">Контакт</button>
+      </div>
+    </div>
+
+    <transition name="modal-fade">
+      <div v-if="contactModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-10" @click.self="closeContacts">
+        <div class="p-4 rounded w-64 select-none" style="background-color: var(--page-bg-color); color: var(--text-color);" @contextmenu.prevent @copy.prevent>
+          <div class="space-y-1 text-sm">
+            <div><span class="text-gray-400">Ссылка:</span> {{ contacts.contact_link || '—' }}</div>
+            <div><span class="text-gray-400">Телефон:</span> {{ contacts.contact_phone || '—' }}</div>
+            <div><span class="text-gray-400">Пароль:</span> {{ contacts.contact_password || '—' }}</div>
+          </div>
+          <button @click="closeContacts" class="mt-3 px-4 py-2 bg-blue-600 text-white rounded w-full">Закрыть</button>
+        </div>
+      </div>
+    </transition>
   </div>
 </template>
 
 <script setup>
-defineProps({ t: Object });
+import { ref, onMounted, watch } from 'vue'
+
+const userId = 1
+
+const categories1 = ref([])
+const categories2 = ref([])
+const selectedCat1 = ref([])
+const selectedCat2 = ref([])
+const suppliers = ref([])
+const showFavOnly = ref(false)
+const contactModal = ref(false)
+const contacts = ref({})
+
+async function loadCategories1() {
+  try {
+    const r = await fetch('http://localhost:8000/suppliers/categories1')
+    if (r.ok) categories1.value = await r.json()
+  } catch (e) { console.error(e) }
+}
+
+async function loadCategories2() {
+  try {
+    const params = selectedCat1.value.join(',')
+    const r = await fetch(`http://localhost:8000/suppliers/categories2?categories1=${encodeURIComponent(params)}`)
+    if (r.ok) categories2.value = await r.json()
+  } catch (e) { console.error(e) }
+}
+
+async function loadSuppliers() {
+  try {
+    const p1 = selectedCat1.value.join(',')
+    const p2 = selectedCat2.value.join(',')
+    const fav = showFavOnly.value ? 'true' : 'false'
+    const url = `http://localhost:8000/suppliers?user_id=${userId}&categories1=${encodeURIComponent(p1)}&categories2=${encodeURIComponent(p2)}&favorites_only=${fav}`
+    const r = await fetch(url)
+    if (r.ok) suppliers.value = await r.json()
+  } catch (e) { console.error(e) }
+}
+
+function toggleCat1(c) {
+  const idx = selectedCat1.value.indexOf(c)
+  if (idx >= 0) selectedCat1.value.splice(idx, 1)
+  else selectedCat1.value.push(c)
+}
+
+function toggleCat2(c) {
+  const idx = selectedCat2.value.indexOf(c)
+  if (idx >= 0) selectedCat2.value.splice(idx, 1)
+  else selectedCat2.value.push(c)
+}
+
+async function toggleFavorite(s) {
+  try {
+    const r = await fetch(`http://localhost:8000/suppliers/${s.id}/favorite`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: userId })
+    })
+    if (r.ok) {
+      const data = await r.json()
+      s.is_favorite = data.favorite
+    }
+  } catch (e) { console.error(e) }
+}
+
+async function openContacts(s) {
+  try {
+    const r = await fetch(`http://localhost:8000/suppliers/${s.id}/contacts`)
+    if (r.ok) {
+      contacts.value = await r.json()
+      contactModal.value = true
+    }
+  } catch (e) { console.error(e) }
+}
+
+function closeContacts() {
+  contactModal.value = false
+  contacts.value = {}
+}
+
+onMounted(() => {
+  loadCategories1()
+  loadCategories2()
+  loadSuppliers()
+})
+
+watch(selectedCat1, () => {
+  loadCategories2()
+  loadSuppliers()
+}, { deep: true })
+
+watch([selectedCat2, showFavOnly], loadSuppliers, { deep: true })
 </script>


### PR DESCRIPTION
## Summary
- add Supplier and FavoriteSupplier models for backend
- implement API routes for categories, supplier listing, contacts and favorites
- seed initial supplier data
- build Suppliers page with categories, brand filter, favorites and contact modal

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685353eeafa8832eaf737cccbaa57896