### PR TITLE
Fix nav overlay

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -221,7 +221,6 @@ function applySafeInsets() {
     const isFullscreen = Telegram.WebApp.isFullscreen;
     const safeInset = Telegram.WebApp.contentSafeAreaInset;
     if (safeInset) {
-      pagesRef.value.style.paddingBottom = `${safeInset.bottom}px`;
       document.querySelector('nav').style.bottom = `${safeInset.bottom}px`;
     }
     document.querySelectorAll('.page').forEach(p => {


### PR DESCRIPTION
## Summary
- remove bottom padding on pages when adjusting safe insets so navigation bar overlays the content

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853ccd03a10832eb4b864d1a7e6eb7b