### PR TITLE
Implement Finds page with backend API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -133,3 +133,17 @@ def toggle_favorite(supplier_id: int, data: dict, db: Session = Depends(get_db))
         db.add(fav)
         db.commit()
         return {'favorite': True}
+
+
+@app.get('/suppliers/{supplier_id}', response_model=schemas.SupplierOut)
+def get_supplier(supplier_id: int, db: Session = Depends(get_db)):
+    s = db.query(models.Supplier).filter(models.Supplier.id == supplier_id).first()
+    if not s:
+        raise HTTPException(status_code=404, detail='Supplier not found')
+    return schemas.SupplierOut.model_validate(s)
+
+
+@app.get('/finds', response_model=list[schemas.FindOut])
+def list_finds(db: Session = Depends(get_db)):
+    items = db.query(models.Find).order_by(models.Find.created_at.desc()).all()
+    return items

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Date, Boolean
+from sqlalchemy import Column, Integer, String, Date, Boolean, DateTime
 from .database import Base
 
 class User(Base):
@@ -43,3 +43,14 @@ class FavoriteSupplier(Base):
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, index=True)
     supplier_id = Column(Integer, index=True)
+
+
+class Find(Base):
+    __tablename__ = 'finds'
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String)
+    description = Column(String)
+    photo_url = Column(String)
+    price = Column(Integer)
+    supplier_id = Column(Integer, index=True)
+    created_at = Column(DateTime)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -58,3 +58,15 @@ class SupplierContacts(BaseModel):
     contact_password: str | None = None
 
     model_config = {"from_attributes": True}
+
+
+class FindOut(BaseModel):
+    id: int
+    name: str
+    description: str | None = None
+    photo_url: str | None = None
+    price: int | None = None
+    supplier_id: int | None = None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,6 +1,6 @@
 from datetime import date
 from .database import engine, SessionLocal
-from .models import User, Affiliate, Supplier, Base
+from .models import User, Affiliate, Supplier, Find, Base
 
 Base.metadata.create_all(bind=engine)
 
@@ -50,6 +50,27 @@ def seed():
             )
         ]
         db.add_all(suppliers)
+        db.commit()
+    if not db.query(Find).first():
+        finds = [
+            Find(
+                name='iPhone 15 Pro',
+                description='Флагманский смартфон 2024 года',
+                photo_url='https://via.placeholder.com/300',
+                price=150000,
+                supplier_id=1,
+                created_at=date(2024, 6, 1)
+            ),
+            Find(
+                name='Кроссовки Limited',
+                description='Редкая модель',
+                photo_url='https://via.placeholder.com/300',
+                price=25000,
+                supplier_id=2,
+                created_at=date(2024, 5, 28)
+            )
+        ]
+        db.add_all(finds)
         db.commit()
     db.close()
 

--- a/src/components/Finds.vue
+++ b/src/components/Finds.vue
@@ -1,10 +1,132 @@
 <template>
-  <div>
-    <h2 class="text-2xl font-bold mb-4 text-center">{{ t.finds }}</h2>
-    <p>Здесь отображаются товары дня.</p>
+  <div class="space-y-4 p-4">
+    <h2 class="text-2xl font-bold text-center">Товары дня</h2>
+
+    <div v-if="error" class="text-center text-red-500 py-10">
+      Не удалось загрузить товары дня. Попробуйте позже.
+    </div>
+    <div v-else-if="loading" class="text-center text-gray-400 py-10">Загрузка...</div>
+    <div v-else-if="!finds.length" class="text-center text-gray-500 py-10">
+      Сегодня пока нет новых товаров
+    </div>
+
+    <div v-else class="space-y-4">
+      <div
+        v-for="f in finds"
+        :key="f.id"
+        class="bg-gray-800 p-4 rounded"
+      >
+        <img
+          :src="f.photo_url"
+          alt=""
+          class="w-full h-48 object-cover rounded mb-3"
+        />
+        <div class="font-semibold truncate mb-1">{{ f.name }}</div>
+        <div class="text-lg font-bold mb-2">{{ formatR(f.price) }}</div>
+        <button
+          @click="openSupplier(f.supplier_id)"
+          class="w-full bg-blue-600 text-white py-2 rounded text-sm"
+        >
+          Смотреть у поставщика
+        </button>
+      </div>
+    </div>
+
+    <transition name="modal-fade">
+      <div
+        v-if="supplierModal"
+        class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-10"
+        @click.self="closeSupplier"
+      >
+        <div
+          class="p-4 rounded w-64 select-none"
+          style="background-color: var(--page-bg-color); color: var(--text-color);"
+          @contextmenu.prevent
+          @copy.prevent
+        >
+          <div class="font-semibold mb-1">{{ supplier.name || 'Поставщик' }}</div>
+          <div class="text-sm text-gray-400 mb-2">{{ supplier.description }}</div>
+          <div class="space-y-1 text-sm">
+            <div>
+              <span class="text-gray-400">Ссылка:</span>
+              {{ supplier.contact_link || '—' }}
+            </div>
+            <div>
+              <span class="text-gray-400">Телефон:</span>
+              {{ supplier.contact_phone || '—' }}
+            </div>
+            <div>
+              <span class="text-gray-400">Пароль:</span>
+              {{ supplier.contact_password || '—' }}
+            </div>
+          </div>
+          <button
+            @click="closeSupplier"
+            class="mt-3 px-4 py-2 bg-blue-600 text-white rounded w-full"
+          >
+            Закрыть
+          </button>
+        </div>
+      </div>
+    </transition>
   </div>
 </template>
 
 <script setup>
-defineProps({ t: Object });
+import { ref, onMounted } from 'vue'
+
+defineProps({ t: Object })
+
+const finds = ref([])
+const loading = ref(true)
+const error = ref(false)
+const supplierModal = ref(false)
+const supplier = ref({})
+
+function formatR(val) {
+  if (val === undefined || val === null) return '—'
+  return new Intl.NumberFormat('ru-RU').format(val) + ' ₽'
+}
+
+async function loadFinds() {
+  loading.value = true
+  error.value = false
+  try {
+    const r = await fetch('http://localhost:8000/finds')
+    if (r.ok) {
+      finds.value = await r.json()
+    } else {
+      error.value = true
+    }
+  } catch (e) {
+    console.error(e)
+    error.value = true
+  } finally {
+    loading.value = false
+  }
+}
+
+async function openSupplier(id) {
+  try {
+    const info = await fetch(`http://localhost:8000/suppliers/${id}`)
+    if (info.ok) {
+      supplier.value = await info.json()
+    }
+    const cont = await fetch(`http://localhost:8000/suppliers/${id}/contacts`)
+    if (cont.ok) {
+      const c = await cont.json()
+      supplier.value = { ...supplier.value, ...c }
+    }
+    supplierModal.value = true
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+function closeSupplier() {
+  supplierModal.value = false
+  supplier.value = {}
+}
+
+onMounted(loadFinds)
 </script>


### PR DESCRIPTION
## Summary
- add `Find` model and API endpoints for finds and supplier details
- seed database with sample finds
- implement Finds page for viewing daily products

## Testing
- `npm install`
- `npm run build`
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6853d81470dc832e849d676ce71dca86