### PR TITLE
Enable CORS in backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, Depends, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 from datetime import date
 
@@ -8,6 +9,20 @@ from .database import SessionLocal, engine
 models.Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
+
+# CORS settings to allow requests from the frontend during development
+origins = [
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # Dependency
 


### PR DESCRIPTION
## Summary
- allow local Vue dev server to access FastAPI API via CORS

## Testing
- `python -m py_compile backend/main.py`
- `python -m pip install -r requirements.txt`
- `uvicorn backend.main:app --port 8000 --reload` (manual check)

------
https://chatgpt.com/codex/tasks/task_e_6853e0676ab8832e9f6820fbba5422db