### PR TITLE
Add global snackbar overlay

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -28,8 +28,9 @@
     <!-- info modal removed -->
 
     <transition name="snackbar-slide">
-      <div v-if="feedSnackbar" class="snackbar p-3 rounded shadow-lg" style="background-color: var(--page-bg-color); color: var(--text-color);">
-        {{ t.feedInDev }}
+      <div v-if="snackbarVisible" class="snackbar p-3 rounded shadow-lg text-sm space-y-1" style="background-color: var(--page-bg-color); color: var(--text-color);">
+        <div v-for="(line, idx) in snackbarLines" :key="idx">{{ line }}</div>
+        <button class="mt-2 bg-blue-600 text-white px-3 py-1 rounded w-full" @click="hideSnackbar">{{ t.close }}</button>
       </div>
     </transition>
   </div>
@@ -61,7 +62,8 @@ const pages = { finds: Finds, suppliers: Suppliers, affiliate: Affiliate, profil
 const lang = ref(localStorage.getItem('lang') || 'ru');
 const t = computed(() => translations[lang.value] || translations.ru);
 const currentIndex = ref(pageOrder.indexOf('finds'));
-const feedSnackbar = ref(false);
+const snackbarVisible = ref(false);
+const snackbarLines = ref([]);
 const pagesRef = ref(null);
 const innerRef = ref(null);
 const navRef = ref(null);
@@ -88,11 +90,20 @@ function showPage(page) {
 }
 
 let snackbarTimer = null;
+function showSnackbar(lines) {
+  snackbarLines.value = Array.isArray(lines) ? lines : [lines];
+  snackbarVisible.value = true;
+  clearTimeout(snackbarTimer);
+  snackbarTimer = setTimeout(() => (snackbarVisible.value = false), 3000);
+}
+
+function hideSnackbar() {
+  snackbarVisible.value = false;
+}
+
 function onNavClick(item) {
   if (item === 'feed') {
-    feedSnackbar.value = true;
-    clearTimeout(snackbarTimer);
-    snackbarTimer = setTimeout(() => (feedSnackbar.value = false), 3000);
+    showSnackbar(t.value.feedInDev);
     return;
   }
   showPage(item);
@@ -225,6 +236,8 @@ function applySafeInsets() {
 }
 window.applySafeInsets = applySafeInsets;
 window.showPage = showPage;
+window.showSnackbar = showSnackbar;
+window.hideSnackbar = hideSnackbar;
 
 onMounted(() => {
   if (window.Telegram?.WebApp) {

--- a/src/components/Finds.vue
+++ b/src/components/Finds.vue
@@ -116,6 +116,12 @@ async function openSupplier(id) {
     if (cont.ok) {
       const c = await cont.json()
       supplier.value = { ...supplier.value, ...c }
+      const lines = [
+        `Ссылка: ${c.contact_link || '—'}`,
+        `Телефон: ${c.contact_phone || '—'}`,
+        `Пароль: ${c.contact_password || '—'}`
+      ]
+      if (window.showSnackbar) window.showSnackbar(lines)
     }
     supplierModal.value = true
   } catch (e) {

--- a/src/components/Suppliers.vue
+++ b/src/components/Suppliers.vue
@@ -50,13 +50,6 @@
       </div>
     </div>
 
-    <transition name="snackbar-slide">
-      <div v-if="contactSnackbar" class="snackbar p-3 rounded shadow-lg text-sm space-y-1" style="background-color: var(--page-bg-color); color: var(--text-color);">
-        <div><span class="text-gray-400">Ссылка:</span> {{ contacts.contact_link || '—' }}</div>
-        <div><span class="text-gray-400">Телефон:</span> {{ contacts.contact_phone || '—' }}</div>
-        <div><span class="text-gray-400">Пароль:</span> {{ contacts.contact_password || '—' }}</div>
-      </div>
-    </transition>
   </div>
 </template>
 
@@ -71,9 +64,6 @@ const selectedCat1 = ref([])
 const selectedCat2 = ref([])
 const suppliers = ref([])
 const showFavOnly = ref(false)
-const contactSnackbar = ref(false)
-const contacts = ref({})
-let snackbarTimer = null
 
 async function loadCategories1() {
   try {
@@ -131,10 +121,13 @@ async function openContacts(s) {
   try {
     const r = await fetch(`http://localhost:8000/suppliers/${s.id}/contacts`)
     if (r.ok) {
-      contacts.value = await r.json()
-      contactSnackbar.value = true
-      clearTimeout(snackbarTimer)
-      snackbarTimer = setTimeout(() => (contactSnackbar.value = false), 3000)
+      const data = await r.json()
+      const lines = [
+        `Ссылка: ${data.contact_link || '—'}`,
+        `Телефон: ${data.contact_phone || '—'}`,
+        `Пароль: ${data.contact_password || '—'}`
+      ]
+      if (window.showSnackbar) window.showSnackbar(lines)
     }
   } catch (e) { console.error(e) }
 }

--- a/src/translations.js
+++ b/src/translations.js
@@ -22,6 +22,7 @@ export const translations = {
     ,chat: 'Чат'
     ,support: 'Техподдержка'
     ,settings: 'Настройки'
+    ,close: 'Закрыть'
   },
   en: {
     feed: 'Feed',
@@ -46,6 +47,7 @@ export const translations = {
     chat: 'Chat',
     support: 'Support',
     settings: 'Settings'
+    ,close: 'Close'
   }
 };
 


### PR DESCRIPTION
## Summary
- provide a global snackbar with close button
- show snackbar on Feed navigation
- show supplier contact data as snackbar for Finds and Suppliers
- add Close to translations

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853eb79c3e0832e8b3cd96ef59ef757