### PR TITLE
Disable auth for testing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,9 @@ const Root = {
     const member = ref(false);
 
     onMounted(async () => {
+      // Authentication disabled for now. Always enable member mode.
+      // Uncomment the code below to restore Telegram WebApp authentication.
+      /*
       if (window.Telegram?.WebApp) {
         try {
           const resp = await fetch('http://localhost:8000/auth/telegram', {
@@ -29,6 +32,8 @@ const Root = {
           console.error(e);
         }
       }
+      */
+      member.value = true;
       loading.value = false;
     });
 


### PR DESCRIPTION
## Summary
- comment out Telegram auth logic

## Testing
- `npm test` *(fails: no test specified)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68542d88e160832e88dcbe6e95be8040