### PR TITLE
Refactor routes using CRUD helpers

### DIFF
--- a/backend/api/affiliate.py
+++ b/backend/api/affiliate.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from .. import models, schemas
+from .. import crud, models, schemas
 from ..database import get_db
 
 router = APIRouter()
@@ -9,7 +9,7 @@ router = APIRouter()
 
 @router.get('/affiliate/{user_id}', response_model=schemas.AffiliateOut)
 def read_affiliate(user_id: int, db: Session = Depends(get_db)):
-    stat = db.query(models.Affiliate).filter(models.Affiliate.user_id == user_id).first()
+    stat = crud.get_affiliate(db, user_id)
     if not stat:
         raise HTTPException(status_code=404, detail='Stats not found')
     return stat
@@ -17,10 +17,7 @@ def read_affiliate(user_id: int, db: Session = Depends(get_db)):
 
 @router.post('/affiliate/{user_id}/withdraw', response_model=schemas.AffiliateOut)
 def request_withdraw(user_id: int, db: Session = Depends(get_db)):
-    stat = db.query(models.Affiliate).filter(models.Affiliate.user_id == user_id).first()
+    stat = crud.request_withdraw(db, user_id)
     if not stat:
         raise HTTPException(status_code=404, detail='Stats not found')
-    stat.withdraw_requested = True
-    db.commit()
-    db.refresh(stat)
     return stat

--- a/backend/api/finds.py
+++ b/backend/api/finds.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from .. import models, schemas
+from .. import crud, models, schemas
 from ..database import get_db
 
 router = APIRouter()
@@ -9,5 +9,4 @@ router = APIRouter()
 
 @router.get('/finds', response_model=list[schemas.FindOut])
 def list_finds(db: Session = Depends(get_db)):
-    items = db.query(models.Find).order_by(models.Find.created_at.desc()).all()
-    return items
+    return crud.list_finds(db)

--- a/backend/api/suppliers.py
+++ b/backend/api/suppliers.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from .. import models, schemas
+from .. import crud, models, schemas
 from ..database import get_db
 
 router = APIRouter()
@@ -9,18 +9,13 @@ router = APIRouter()
 
 @router.get('/suppliers/categories1')
 def get_categories1(db: Session = Depends(get_db)):
-    cats = db.query(models.Supplier.category1).distinct().all()
-    return [c[0] for c in cats if c[0]]
+    return crud.list_categories1(db)
 
 
 @router.get('/suppliers/categories2')
 def get_categories2(categories1: str = '', db: Session = Depends(get_db)):
-    q = db.query(models.Supplier.category2)
-    if categories1:
-        cats1 = [c.strip() for c in categories1.split(',') if c.strip()]
-        q = q.filter(models.Supplier.category1.in_(cats1))
-    cats = q.distinct().all()
-    return [c[0] for c in cats if c[0]]
+    cats1 = [c.strip() for c in categories1.split(',') if c.strip()]
+    return crud.list_categories2(db, cats1)
 
 
 @router.get('/suppliers', response_model=list[schemas.SupplierOut])
@@ -31,17 +26,10 @@ def list_suppliers(
     favorites_only: bool = False,
     db: Session = Depends(get_db),
 ):
-    q = db.query(models.Supplier)
-    if categories1:
-        cats1 = [c.strip() for c in categories1.split(',') if c.strip()]
-        q = q.filter(models.Supplier.category1.in_(cats1))
-    if categories2:
-        cats2 = [c.strip() for c in categories2.split(',') if c.strip()]
-        q = q.filter(models.Supplier.category2.in_(cats2))
-    suppliers = q.all()
-    fav_ids = set(
-        r.supplier_id for r in db.query(models.FavoriteSupplier).filter(models.FavoriteSupplier.user_id == user_id)
-    )
+    cats1 = [c.strip() for c in categories1.split(',') if c.strip()]
+    cats2 = [c.strip() for c in categories2.split(',') if c.strip()]
+    suppliers = crud.list_suppliers(db, cats1, cats2)
+    fav_ids = set(crud.get_favorite_supplier_ids(db, user_id))
     if favorites_only:
         suppliers = [s for s in suppliers if s.id in fav_ids]
     result = []
@@ -54,7 +42,7 @@ def list_suppliers(
 
 @router.get('/suppliers/{supplier_id}/contacts', response_model=schemas.SupplierContacts)
 def get_supplier_contacts(supplier_id: int, db: Session = Depends(get_db)):
-    s = db.query(models.Supplier).filter(models.Supplier.id == supplier_id).first()
+    s = crud.get_supplier(db, supplier_id)
     if not s:
         raise HTTPException(status_code=404, detail='Supplier not found')
     return schemas.SupplierContacts.model_validate(s)
@@ -65,24 +53,13 @@ def toggle_favorite(supplier_id: int, data: dict, db: Session = Depends(get_db))
     user_id = data.get('user_id')
     if not user_id:
         raise HTTPException(status_code=400, detail='user_id required')
-    fav = db.query(models.FavoriteSupplier).filter(
-        models.FavoriteSupplier.user_id == user_id,
-        models.FavoriteSupplier.supplier_id == supplier_id,
-    ).first()
-    if fav:
-        db.delete(fav)
-        db.commit()
-        return {'favorite': False}
-    else:
-        fav = models.FavoriteSupplier(user_id=user_id, supplier_id=supplier_id)
-        db.add(fav)
-        db.commit()
-        return {'favorite': True}
+    favorite = crud.toggle_favorite_supplier(db, user_id, supplier_id)
+    return {'favorite': favorite}
 
 
 @router.get('/suppliers/{supplier_id}', response_model=schemas.SupplierOut)
 def get_supplier(supplier_id: int, db: Session = Depends(get_db)):
-    s = db.query(models.Supplier).filter(models.Supplier.id == supplier_id).first()
+    s = crud.get_supplier(db, supplier_id)
     if not s:
         raise HTTPException(status_code=404, detail='Supplier not found')
     return schemas.SupplierOut.model_validate(s)

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -3,7 +3,7 @@ from datetime import date
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from .. import models, schemas
+from .. import crud, models, schemas
 from ..database import get_db
 
 router = APIRouter()
@@ -11,7 +11,7 @@ router = APIRouter()
 
 @router.get('/users/{user_id}', response_model=schemas.UserOut)
 def read_user(user_id: int, db: Session = Depends(get_db)):
-    user = db.query(models.User).filter(models.User.id == user_id).first()
+    user = crud.get_user(db, user_id)
     if not user:
         raise HTTPException(status_code=404, detail='User not found')
     result = schemas.UserOut.model_validate(user)
@@ -32,11 +32,7 @@ def read_user(user_id: int, db: Session = Depends(get_db)):
 
 @router.patch('/users/{user_id}', response_model=schemas.UserOut)
 def update_user(user_id: int, data: schemas.UserBase, db: Session = Depends(get_db)):
-    user = db.query(models.User).filter(models.User.id == user_id).first()
+    user = crud.update_user(db, user_id, location=data.location)
     if not user:
         raise HTTPException(status_code=404, detail='User not found')
-    if data.location is not None:
-        user.location = data.location
-    db.commit()
-    db.refresh(user)
     return read_user(user_id, db)

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from . import models
+
+
+def get_user(db: Session, user_id: int) -> models.User | None:
+    """Return user by id or None."""
+    return db.query(models.User).filter(models.User.id == user_id).first()
+
+
+def update_user(db: Session, user_id: int, *, location: str | None = None) -> models.User | None:
+    """Update user fields and return updated instance or None if not found."""
+    user = get_user(db, user_id)
+    if not user:
+        return None
+    if location is not None:
+        user.location = location
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def get_affiliate(db: Session, user_id: int) -> models.Affiliate | None:
+    return db.query(models.Affiliate).filter(models.Affiliate.user_id == user_id).first()
+
+
+def request_withdraw(db: Session, user_id: int) -> models.Affiliate | None:
+    stat = get_affiliate(db, user_id)
+    if not stat:
+        return None
+    stat.withdraw_requested = True
+    db.commit()
+    db.refresh(stat)
+    return stat
+
+
+def list_categories1(db: Session) -> list[str]:
+    cats = db.query(models.Supplier.category1).distinct().all()
+    return [c[0] for c in cats if c[0]]
+
+
+def list_categories2(db: Session, categories1: list[str] | None = None) -> list[str]:
+    q = db.query(models.Supplier.category2)
+    if categories1:
+        q = q.filter(models.Supplier.category1.in_(categories1))
+    cats = q.distinct().all()
+    return [c[0] for c in cats if c[0]]
+
+
+def list_suppliers(
+    db: Session,
+    categories1: list[str] | None = None,
+    categories2: list[str] | None = None,
+) -> list[models.Supplier]:
+    q = db.query(models.Supplier)
+    if categories1:
+        q = q.filter(models.Supplier.category1.in_(categories1))
+    if categories2:
+        q = q.filter(models.Supplier.category2.in_(categories2))
+    return q.all()
+
+
+def get_favorite_supplier_ids(db: Session, user_id: int) -> list[int]:
+    return [
+        r.supplier_id
+        for r in db.query(models.FavoriteSupplier).filter(models.FavoriteSupplier.user_id == user_id)
+    ]
+
+
+def toggle_favorite_supplier(db: Session, user_id: int, supplier_id: int) -> bool:
+    fav = db.query(models.FavoriteSupplier).filter(
+        models.FavoriteSupplier.user_id == user_id,
+        models.FavoriteSupplier.supplier_id == supplier_id,
+    ).first()
+    if fav:
+        db.delete(fav)
+        db.commit()
+        return False
+    else:
+        fav = models.FavoriteSupplier(user_id=user_id, supplier_id=supplier_id)
+        db.add(fav)
+        db.commit()
+        return True
+
+
+def get_supplier(db: Session, supplier_id: int) -> models.Supplier | None:
+    return db.query(models.Supplier).filter(models.Supplier.id == supplier_id).first()
+
+
+def list_finds(db: Session) -> list[models.Find]:
+    return db.query(models.Find).order_by(models.Find.created_at.desc()).all()


### PR DESCRIPTION
## Summary
- add `backend/crud.py` with helper utilities
- refactor API routes to call CRUD helpers instead of direct `Session`

## Testing
- `python -m py_compile backend/crud.py backend/api/users.py backend/api/affiliate.py backend/api/suppliers.py backend/api/finds.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68547f24fd74832e8c31c38544b02df7