### PR TITLE
Add API tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sqlalchemy
 psycopg2-binary
 alembic
 pydantic-settings
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,56 @@
+import os
+import sys
+from datetime import date, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from backend.main import app
+from backend import models
+from backend.database import get_db
+
+
+@pytest.fixture()
+def client(tmp_path):
+    db_path = tmp_path / 'test.db'
+    engine = create_engine(f'sqlite:///{db_path}', connect_args={'check_same_thread': False})
+    TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    models.Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.state.SessionLocal = TestingSessionLocal
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def db_session(client):
+    SessionLocal = client.app.state.SessionLocal
+    db = SessionLocal()
+    user = models.User(agent_number='agent', join_date=date(2024, 1, 1), location='Moscow')
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    affiliate = models.Affiliate(user_id=user.id)
+    supplier1 = models.Supplier(name='Store A', contact_link='link')
+    supplier2 = models.Supplier(name='Store B', contact_link='link')
+    find = models.Find(name='Item', supplier_id=1, created_at=datetime.utcnow())
+    db.add_all([affiliate, supplier1, supplier2, find])
+    db.commit()
+    client.app.state.user_id = user.id
+    try:
+        yield db
+    finally:
+        db.close()

--- a/tests/test_affiliate.py
+++ b/tests/test_affiliate.py
@@ -1,0 +1,18 @@
+
+def test_read_affiliate(client, db_session):
+    uid = client.app.state.user_id
+    resp = client.get(f'/affiliate/{uid}')
+    assert resp.status_code == 200
+    assert resp.json()['user_id'] == uid
+
+
+def test_affiliate_not_found(client, db_session):
+    resp = client.get('/affiliate/999')
+    assert resp.status_code == 404
+
+
+def test_request_withdraw(client, db_session):
+    uid = client.app.state.user_id
+    resp = client.post(f'/affiliate/{uid}/withdraw')
+    assert resp.status_code == 200
+    assert resp.json()['withdraw_requested'] is True

--- a/tests/test_finds.py
+++ b/tests/test_finds.py
@@ -1,0 +1,5 @@
+
+def test_list_finds(client, db_session):
+    resp = client.get('/finds')
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1

--- a/tests/test_suppliers.py
+++ b/tests/test_suppliers.py
@@ -1,0 +1,34 @@
+
+def test_list_suppliers(client, db_session):
+    uid = client.app.state.user_id
+    resp = client.get('/suppliers', params={'user_id': uid})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+
+def test_get_supplier(client, db_session):
+    resp = client.get('/suppliers/1')
+    assert resp.status_code == 200
+    assert resp.json()['id'] == 1
+
+
+def test_get_supplier_not_found(client, db_session):
+    resp = client.get('/suppliers/999')
+    assert resp.status_code == 404
+
+
+def test_get_supplier_contacts(client, db_session):
+    resp = client.get('/suppliers/1/contacts')
+    assert resp.status_code == 200
+    assert 'contact_link' in resp.json()
+
+
+def test_toggle_favorite(client, db_session):
+    uid = client.app.state.user_id
+    resp = client.post('/suppliers/1/favorite', json={'user_id': uid})
+    assert resp.status_code == 200
+    assert resp.json()['favorite'] is True
+    # Should now show only one supplier when favorites_only is true
+    resp2 = client.get('/suppliers', params={'user_id': uid, 'favorites_only': True})
+    assert resp2.status_code == 200
+    assert len(resp2.json()) == 1

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,21 @@
+def test_read_user(client, db_session):
+    uid = client.app.state.user_id
+    response = client.get(f'/users/{uid}')
+    assert response.status_code == 200
+    data = response.json()
+    assert data['id'] == uid
+
+
+def test_read_user_not_found(client, db_session):
+    response = client.get('/users/999')
+    assert response.status_code == 404
+
+
+def test_update_user(client, db_session):
+    uid = client.app.state.user_id
+    response = client.patch(
+        f'/users/{uid}',
+        json={'agent_number': 'agent', 'location': 'NY'}
+    )
+    assert response.status_code == 200
+    assert response.json()['location'] == 'NY'


### PR DESCRIPTION
## Summary
- add pytest to requirements
- create API tests using TestClient and a temp SQLite database

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854810bbbf8832ea2dfcf722b006fab