### PR TITLE
Fix user-specific API calls

### DIFF
--- a/src/components/Affiliate.vue
+++ b/src/components/Affiliate.vue
@@ -76,6 +76,7 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue';
 import { API_BASE } from '../api';
+import { userData } from '../state';
 
 const props = defineProps({ t: Object });
 
@@ -93,7 +94,7 @@ const canWithdraw = computed(() => (stats.value.balance || 0) >= 5000);
 
 async function loadData() {
   try {
-    const respUser = await fetch(`${API_BASE}/users/1`);
+    const respUser = await fetch(`${API_BASE}/users/${userData.user.id}`);
     if (respUser.ok) {
       const user = await respUser.json();
       nickname.value = 'Агент ' + (user.agent_number || '—');
@@ -102,7 +103,7 @@ async function loadData() {
     console.error(e);
   }
   try {
-    const resp = await fetch(`${API_BASE}/affiliate/1`);
+    const resp = await fetch(`${API_BASE}/affiliate/${userData.user.id}`);
     if (resp.ok) {
       stats.value = await resp.json();
       withdrawRequested.value = stats.value.withdraw_requested;
@@ -114,7 +115,7 @@ async function loadData() {
 
 async function onWithdraw() {
   try {
-    const resp = await fetch(`${API_BASE}/affiliate/1/withdraw`, { method: 'POST' });
+    const resp = await fetch(`${API_BASE}/affiliate/${userData.user.id}/withdraw`, { method: 'POST' });
     if (resp.ok) {
       const data = await resp.json();
       stats.value = data;

--- a/src/components/Profile.vue
+++ b/src/components/Profile.vue
@@ -40,7 +40,7 @@ const numDisplay = computed(() => {
 
 async function loadUser() {
   try {
-    const resp = await fetch(`${API_BASE}/users/1`);
+    const resp = await fetch(`${API_BASE}/users/${userData.user.id}`);
     if (resp.ok) {
       const data = await resp.json();
       userData.user = data;

--- a/src/components/ProfileSettings.vue
+++ b/src/components/ProfileSettings.vue
@@ -52,7 +52,7 @@ const fullscreen = ref(false);
 
 async function loadUser() {
   try {
-    const resp = await fetch(`${API_BASE}/users/1`);
+    const resp = await fetch(`${API_BASE}/users/${userData.user.id}`);
     if (resp.ok) {
       const data = await resp.json();
       userData.user = data;
@@ -97,7 +97,7 @@ function changeLang(e) {
 
 async function saveLocation() {
   try {
-    await fetch(`${API_BASE}/users/1`, {
+    await fetch(`${API_BASE}/users/${userData.user.id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ location: location.value, agent_number: user.value.agent_number })


### PR DESCRIPTION
## Summary
- fetch the authenticated user's profile instead of always using ID 1
- use logged-in user ID for affiliate endpoints

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854cbdad51c832e96b17fce314880f6