### PR TITLE
Implement sequential agent numbers

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -94,10 +94,11 @@ async def telegram_auth(request: Request, db: AsyncSession = Depends(get_db)):
                 referrer_id = crud.decode_referral(ref_param)
             except Exception:
                 referrer_id = None
+        agent_number = await crud.generate_agent_number(db)
         user = await crud.create_user(
             db,
             user_id=user_id,
-            agent_number=username,
+            agent_number=agent_number,
             referrer_id=referrer_id,
         )
         await crud.create_affiliate(db, user.id)
@@ -106,7 +107,7 @@ async def telegram_auth(request: Request, db: AsyncSession = Depends(get_db)):
         "id": user.id,
         "first_name": first_name,
         "last_name": last_name,
-        "username": username,
+        "username": user.agent_number,
         "is_member": user.is_member
     }
 

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -23,6 +23,18 @@ def generate_referral_link(user_id: int) -> str:
     return f"https://t.me/club_bot?start={code}"
 
 
+async def generate_agent_number(db: AsyncSession) -> str:
+    """Return next agent number like chn_001, chn_002, ..."""
+    result = await db.execute(select(models.User.agent_number))
+    max_num = 0
+    for agent in result.scalars().all():
+        if agent and agent.startswith("chn_"):
+            part = agent.split("_")[-1]
+            if part.isdigit():
+                max_num = max(max_num, int(part))
+    return f"chn_{max_num + 1:03d}"
+
+
 async def create_user(
     db: AsyncSession,
     *,

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,3 +1,7 @@
+import asyncio
+from backend import crud
+
+
 def test_read_user(client, db_session):
     uid = client.app.state.user_id
     response = client.get(f'/users/{uid}')
@@ -26,3 +30,18 @@ def test_pay_membership(client, db_session):
     resp = client.post(f'/users/{uid}/pay')
     assert resp.status_code == 200
     assert resp.json()['is_member'] is True
+
+
+def test_generate_agent_number(client, db_session):
+    SessionLocal = client.app.state.SessionLocal
+
+    async def run():
+        async with SessionLocal() as db:
+            num1 = await crud.generate_agent_number(db)
+            await crud.create_user(db, user_id=2, agent_number=num1)
+            num2 = await crud.generate_agent_number(db)
+            return num1, num2
+
+    num1, num2 = asyncio.get_event_loop().run_until_complete(run())
+    assert num1 == 'chn_001'
+    assert num2 == 'chn_002'


### PR DESCRIPTION
## Summary
- generate unique agent numbers automatically
- use generated agent numbers when authenticating via Telegram
- test agent number generation logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854d6acdb78832e98bc12a173be88aa