### PR TITLE
Handle delayed Telegram auth

### DIFF
--- a/src/components/Affiliate.vue
+++ b/src/components/Affiliate.vue
@@ -74,7 +74,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted, watch, computed } from 'vue';
 import { userData } from '../state';
 import { API_BASE } from '../api';
 
@@ -93,6 +93,7 @@ function formatR(val) {
 const canWithdraw = computed(() => (stats.value.balance || 0) >= 5000);
 
 async function loadData() {
+  if (!userData.user.id) return;
   try {
     const respUser = await fetch(`${API_BASE}/users/${userData.user.id}`);
     if (respUser.ok) {
@@ -131,4 +132,8 @@ function copyLink() {
 }
 
 onMounted(loadData);
+
+watch(() => userData.user.id, id => {
+  if (id) loadData();
+});
 </script>

--- a/src/components/Payment.vue
+++ b/src/components/Payment.vue
@@ -10,6 +10,7 @@ import { API_BASE } from '../api'
 const emit = defineEmits(['paid'])
 
 async function pay() {
+  if (!userData.user.id) return
   try {
     await fetch(`${API_BASE}/users/${userData.user.id}/pay`, { method: 'POST' })
     userData.user.is_member = true

--- a/src/components/Profile.vue
+++ b/src/components/Profile.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted, watch, computed } from 'vue';
 import { userData } from '../state';
 import { API_BASE } from '../api';
 const props = defineProps({ t: Object });
@@ -39,6 +39,7 @@ const numDisplay = computed(() => {
 });
 
 async function loadUser() {
+  if (!userData.user.id) return;
   try {
     const resp = await fetch(`${API_BASE}/users/${userData.user.id}`);
     if (resp.ok) {
@@ -56,6 +57,10 @@ function openSettings() {
 }
 
 onMounted(loadUser);
+
+watch(() => userData.user.id, id => {
+  if (id) loadUser();
+});
 </script>
 
 <style scoped>

--- a/src/components/ProfileSettings.vue
+++ b/src/components/ProfileSettings.vue
@@ -51,6 +51,7 @@ const lang = ref(localStorage.getItem('lang') || 'ru');
 const fullscreen = ref(false);
 
 async function loadUser() {
+  if (!userData.user.id) return;
   try {
     const resp = await fetch(`${API_BASE}/users/${userData.user.id}`);
     if (resp.ok) {
@@ -68,6 +69,10 @@ async function loadUser() {
 }
 
 onMounted(loadUser);
+
+watch(() => userData.user.id, id => {
+  if (id) loadUser();
+});
 
 function toggleTheme() {
   theme.value = theme.value === 'dark' ? 'light' : 'dark';

--- a/src/components/Suppliers.vue
+++ b/src/components/Suppliers.vue
@@ -81,6 +81,7 @@ async function loadCategories2() {
 }
 
 async function loadSuppliers() {
+  if (!userData.user.id) return
   try {
     const p1 = selectedCat1.value.join(',')
     const p2 = selectedCat2.value.join(',')
@@ -137,6 +138,10 @@ onMounted(() => {
   loadCategories1()
   loadCategories2()
   loadSuppliers()
+})
+
+watch(() => userData.user.id, id => {
+  if (id) loadSuppliers()
 })
 
 watch(selectedCat1, () => {

--- a/src/state.js
+++ b/src/state.js
@@ -1,7 +1,9 @@
 import { reactive } from 'vue';
 
+const initialUser = window.Telegram?.WebApp?.initDataUnsafe?.user || {};
+
 export const userData = reactive({
-  user: {},
+  user: initialUser,
   score: Math.floor(Math.random() * 1000),
   rank: 0
 });


### PR DESCRIPTION
## Summary
- initialize user data from `window.Telegram` when available
- guard supplier/API requests until `userData.user.id` exists
- watch for `userData.user.id` so components reload once auth completes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855066eef98832eb84dba4f0e63259b