### PR TITLE
Convert snackbars to bottom sheet overlay

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -282,8 +282,12 @@ onMounted(() => {
       </button>
     </nav>
     <transition name="modal-fade">
-      <div v-if="sheetVisible" class="fixed bottom-20 inset-x-0 mx-4 p-4 bg-gray-800 rounded" @click="hideSheet">
-        <p v-for="l in sheetLines" :key="l">{{ l }}</p>
+      <div v-if="sheetVisible" class="bottom-sheet-overlay" @click.self="hideSheet">
+        <transition name="sheet-slide">
+          <div v-if="sheetVisible" class="bottom-sheet mx-4 mb-4 p-4 bg-gray-800" @click.stop>
+            <p v-for="l in sheetLines" :key="l">{{ l }}</p>
+          </div>
+        </transition>
       </div>
     </transition>
   </div>

--- a/src/style.css
+++ b/src/style.css
@@ -118,26 +118,13 @@ nav.show-labels .nav-label {
 .modal-fade-leave-to {
   opacity: 0;
 }
-.snackbar {
-  position: fixed;
-  left: 50%;
-  bottom: calc(80px + 1rem);
-  transform: translateX(-50%);
-  z-index: 1100;
-}
-.snackbar-slide-enter-from,
-.snackbar-slide-leave-to {
-  opacity: 0;
-  transform: translate(-50%, 100%);
-}
-.snackbar-slide-enter-active,
-.snackbar-slide-leave-active {
-  transition: transform 0.3s, opacity 0.3s;
-}
 
 .bottom-sheet-overlay {
   position: fixed;
   inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
   background-color: transparent;
   z-index: 1100;
 }


### PR DESCRIPTION
## Summary
- drop old snackbar styles
- add bottom sheet overlay with slide animation
- show messages using bottom sheet instead of snackbar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856440ac5a8832ea386a795f8687cf1