### PR TITLE
Fix scroll issue in goods and suppliers pages

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -23,6 +23,7 @@ body {
 .page {
   background-color: var(--page-bg-color);
   overscroll-behavior-y: contain;
+  height: 100%;
 }
 nav {
   position: fixed;


### PR DESCRIPTION
## Summary
- ensure `.page` elements have explicit height so product and supplier lists can scroll

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68564b5a16ec832ea4a3624d5b6586af