### PR TITLE
Fix overscroll logic to allow page scrolling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -200,7 +200,8 @@ onMounted(() => {
       const diff = cy - sy;
       const atTop = page.scrollTop <= 0;
       const atBottom = page.scrollTop + page.clientHeight >= page.scrollHeight;
-      if ((atTop && diff > 0) || (atBottom && diff < 0)) {
+      const hasScrollable = page.scrollHeight > page.clientHeight;
+      if (hasScrollable && ((atTop && diff > 0) || (atBottom && diff < 0))) {
         e.preventDefault();
         pulling = true;
         page.style.transform = `translateY(${diff / 4}px)`;


### PR DESCRIPTION
## Summary
- avoid preventing scroll if the page content isn't long enough

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685659728ea4832ebcff90da71c96fa1