### PR TITLE
Fix top padding when Telegram app is fullscreen

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -275,20 +275,21 @@ function applySafeInsets() {
   if (window.Telegram?.WebApp) {
     const isFullscreen = Telegram.WebApp.isFullscreen;
     const safeInset = Telegram.WebApp.contentSafeAreaInset || {};
+    const insetTop = parseInt(safeInset.top) || 0;
     const insetBottom = parseInt(safeInset.bottom) || 0;
     const navHeight = 70;
 
     navBottom.value = insetBottom;
 
     document.querySelectorAll('.page').forEach(p => {
-      // Добавляем/удаляем класс safe-area
       if (isFullscreen) {
         p.classList.add('safe-area');
+        p.style.paddingTop = `${28 + insetTop}px`;
       } else {
         p.classList.remove('safe-area');
+        p.style.paddingTop = '';
       }
 
-      // Устанавливаем padding-bottom через JS (если нужно)
       p.style.paddingBottom = `${navHeight + insetBottom}px`;
     });
   }

--- a/src/style.css
+++ b/src/style.css
@@ -36,7 +36,7 @@ body {
 
 }
 .safe-area {
-  padding-top: calc(28px + env(safe-area-inset-top));
+  padding-top: env(safe-area-inset-top);
 }
 
 


### PR DESCRIPTION
## Summary
- apply safe area top from Telegram API when fullscreen
- use safe-area-inset-top in CSS as fallback

## Testing
- `pytest` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583c57db80832eb568082bd5980a46