### PR TITLE
Add custom SVG icon loader

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,13 +18,12 @@ import { API_BASE } from './api';
 
 const navItems = ['feed', 'finds', 'suppliers', 'affiliate', 'profile'];
 const pageOrder = ['finds', 'suppliers', 'affiliate', 'profile', 'settings'];
-const pageIcons = {
-  feed: 'fas fa-rss',
-  finds: 'fas fa-star',
-  suppliers: 'fas fa-truck',
-  affiliate: 'fas fa-handshake',
-  profile: 'fas fa-user'
-};
+const svgModules = import.meta.glob('./icons/*.svg', { as: 'raw', eager: true });
+const pageIcons = {};
+for (const path in svgModules) {
+  const name = path.replace('./icons/', '').replace('.svg', '');
+  pageIcons[name] = svgModules[path];
+}
 
 const pages = { finds: Finds, suppliers: Suppliers, affiliate: Affiliate, profile: Profile, settings: ProfileSettings };
 
@@ -328,7 +327,7 @@ onMounted(() => {
     </div>
     <nav ref="navRef" :class="{'show-labels': showLabels} " :style="{ bottom: navBottom + 'px' }">
       <button v-for="item in navItems" :key="item" class="nav-btn" :class="{ active: pageOrder[currentIndex]===item }" @click="onNavClick(item)">
-        <i :class="['icon', pageIcons[item]]"></i>
+        <span class="icon" v-html="pageIcons[item]"></span>
         <span class="nav-label">{{ t[item] }}</span>
       </button>
     </nav>

--- a/src/icons/README.md
+++ b/src/icons/README.md
@@ -1,0 +1,6 @@
+# Custom Icons
+
+Place your SVG files here to replace the default navigation icons.
+Each file name should correspond to the navigation key:
+`feed.svg`, `finds.svg`, `suppliers.svg`, `affiliate.svg`, `profile.svg`.
+The icons are loaded automatically using Vite's `import.meta.glob`.

--- a/src/icons/affiliate.svg
+++ b/src/icons/affiliate.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+  <polygon points="12,2 22,22 2,22" />
+</svg>

--- a/src/icons/feed.svg
+++ b/src/icons/feed.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+  <rect x="4" y="4" width="16" height="16" rx="2"/>
+</svg>

--- a/src/icons/finds.svg
+++ b/src/icons/finds.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+  <circle cx="12" cy="12" r="10" />
+</svg>

--- a/src/icons/profile.svg
+++ b/src/icons/profile.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+  <circle cx="12" cy="8" r="4" />
+  <path d="M4 20c0-4 4-6 8-6s8 2 8 6" />
+</svg>

--- a/src/icons/suppliers.svg
+++ b/src/icons/suppliers.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+  <path d="M4 4h16v16H4z"/>
+</svg>

--- a/src/style.css
+++ b/src/style.css
@@ -79,7 +79,9 @@ nav {
 }
 
 .nav-btn .icon {
-  font-size: 26px;
+  width: 26px;
+  height: 26px;
+  display: inline-block;
   color: #6b7280; /* неактивный — серый */
   transition: color 0.25s, transform 0.3s;
   z-index: 1;


### PR DESCRIPTION
## Summary
- enable loading navigation icons from local SVGs
- document how to add user-defined SVGs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68585010b154832eb0245e0f207419a4