### PR TITLE
Add product categories filtering

### DIFF
--- a/backend/api/finds.py
+++ b/backend/api/finds.py
@@ -7,7 +7,24 @@ from ..database import get_db
 router = APIRouter()
 
 
+@router.get('/finds/categories1')
+async def get_categories1(db: AsyncSession = Depends(get_db)):
+    return await crud.list_find_categories1(db)
+
+
+@router.get('/finds/categories2')
+async def get_categories2(categories1: str = '', db: AsyncSession = Depends(get_db)):
+    cats1 = [c.strip() for c in categories1.split(',') if c.strip()]
+    return await crud.list_find_categories2(db, cats1)
+
+
 @router.get('/finds', response_model=list[schemas.FindOut])
-async def list_finds(db: AsyncSession = Depends(get_db)):
-    return await crud.list_finds(db)
+async def list_finds(
+    categories1: str = '',
+    categories2: str = '',
+    db: AsyncSession = Depends(get_db)
+):
+    cats1 = [c.strip() for c in categories1.split(',') if c.strip()]
+    cats2 = [c.strip() for c in categories2.split(',') if c.strip()]
+    return await crud.list_finds(db, cats1, cats2)
 

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -172,7 +172,30 @@ async def get_supplier(db: AsyncSession, supplier_id: int) -> models.Supplier | 
     result = await db.execute(select(models.Supplier).where(models.Supplier.id == supplier_id))
     return result.scalar_one_or_none()
 
+async def list_find_categories1(db: AsyncSession) -> list[str]:
+    result = await db.execute(select(models.Find.category1).distinct())
+    cats = result.scalars().all()
+    return [c for c in cats if c]
 
-async def list_finds(db: AsyncSession) -> list[models.Find]:
-    result = await db.execute(select(models.Find).order_by(models.Find.created_at.desc()))
+
+async def list_find_categories2(db: AsyncSession, categories1: list[str] | None = None) -> list[str]:
+    stmt = select(models.Find.category2)
+    if categories1:
+        stmt = stmt.where(models.Find.category1.in_(categories1))
+    result = await db.execute(stmt.distinct())
+    cats = result.scalars().all()
+    return [c for c in cats if c]
+
+
+async def list_finds(
+    db: AsyncSession,
+    categories1: list[str] | None = None,
+    categories2: list[str] | None = None,
+) -> list[models.Find]:
+    stmt = select(models.Find).order_by(models.Find.created_at.desc())
+    if categories1:
+        stmt = stmt.where(models.Find.category1.in_(categories1))
+    if categories2:
+        stmt = stmt.where(models.Find.category2.in_(categories2))
+    result = await db.execute(stmt)
     return result.scalars().all()

--- a/backend/models.py
+++ b/backend/models.py
@@ -59,6 +59,8 @@ class Find(Base):
     name = Column(String)
     description = Column(String)
     photo_url = Column(String)
+    category1 = Column(String)
+    category2 = Column(String)
     price = Column(Integer)
     supplier_id = Column(Integer, index=True)
     created_at = Column(DateTime)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -66,6 +66,8 @@ class FindOut(BaseModel):
     name: str
     description: str | None = None
     photo_url: str | None = None
+    category1: str | None = None
+    category2: str | None = None
     price: int | None = None
     supplier_id: int | None = None
     created_at: datetime

--- a/migrations/versions/aa2d3456b789_add_categories_to_find.py
+++ b/migrations/versions/aa2d3456b789_add_categories_to_find.py
@@ -1,0 +1,28 @@
+"""add categories to find
+
+Revision ID: aa2d3456b789
+Revises: e7d7ecc8e6d2
+Create Date: 2025-07-21 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'aa2d3456b789'
+down_revision: Union[str, Sequence[str], None] = 'e7d7ecc8e6d2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('finds', sa.Column('category1', sa.String(), nullable=True))
+    op.add_column('finds', sa.Column('category2', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('finds', 'category2')
+    op.drop_column('finds', 'category1')

--- a/src/components/Finds.vue
+++ b/src/components/Finds.vue
@@ -1,18 +1,90 @@
 <!--Funds.vue-->
 <template>
-  <div class="finds-container h-full flex flex-col">
+  <div class="h-full flex flex-col space-y-1 p-2">
     <!-- 🔒 Фиксированная шапка -->
-    <div class="sticky top-0 z-10 bg-[var(--page-bg-color)] px-3 py-4 border-b border-[#2c2c3a]">
-      <div class="flex items-center justify-between">
-        <span class="text-lg font-bold">Finds</span>
-        <span class="text-2xl font-extrabold">1chn</span>
-        <button class="text-purple-400 text-sm font-bold flex items-center gap-1">
-          <span>Filters</span>
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path d="M19 9l-7 7-7-7"/>
+    <div class="sticky top-0 z-10 bg-[var(--page-bg-color)] space-y-3 px-3 py-4 border-b border-[#2c2c3a]">
+      <div class="relative flex items-center justify-between">
+        <span class="text-lg font-bold text-white">Finds</span>
+
+        <!-- Центрированный заголовок -->
+        <div class="absolute left-1/2 transform -translate-x-1/2 flex flex-col items-center">
+          <span class="text-2xl font-extrabold text-white">1chn</span>
+          <span class="text-sm text-gray-400">[ван чан]</span>
+        </div>
+
+        <!-- Сердце с счётчиком -->
+        <div class="relative w-6 h-6">
+          <svg
+            @click="showFavOnly = !showFavOnly"
+            class="heart-icon"
+            :class="showFavOnly ? 'heart-active' : 'heart-inactive'"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5
+              2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09
+              C13.09 3.81 14.76 3 16.5 3
+              19.58 3 22 5.42 22 8.5
+              c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+            />
           </svg>
+          <span
+            class="absolute -bottom-1 -right-2 bg-black text-white text-[10px] rounded-full w-4 h-4 flex items-center justify-center border border-white"
+          >
+            {{ favoritesCount }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Кнопка фильтра -->
+      <div class="mt-3">
+        <button
+          @click="filtersOpen = !filtersOpen"
+          class="w-full bg-purple-700 text-white font-semibold py-1 rounded text-sm"
+        >
+          Filters
+          <span :class="filtersOpen ? 'rotate-180' : ''" class="inline-block transition-transform ml-1">▼</span>
         </button>
       </div>
+
+      <!-- Выпадающие фильтры -->
+      <transition name="fade">
+        <div v-if="filtersOpen" class="px-1 py-3 bg-[var(--page-bg-color)] space-y-3 border-b border-[#2c2c3a]">
+          <div>
+            <div class="text-sm mb-1 text-white">Категория</div>
+            <div class="flex flex-wrap gap-2">
+              <button
+                v-for="c in categories1"
+                :key="c"
+                @click="toggleCat1(c)"
+                :class="[
+                  'px-3 py-1 rounded-full text-sm border',
+                  selectedCat1.includes(c) ? 'bg-blue-600 text-white' : 'bg-gray-700 text-white'
+                ]"
+              >
+                {{ c }}
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <div class="text-sm mb-1 text-white">Бренд</div>
+            <div class="flex flex-wrap gap-2">
+              <button
+                v-for="b in categories2"
+                :key="b"
+                @click="toggleCat2(b)"
+                :class="[
+                  'px-3 py-1 rounded-full text-sm border',
+                  selectedCat2.includes(b) ? 'bg-blue-600 text-white' : 'bg-gray-700 text-white'
+                ]"
+              >
+                {{ b }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </transition>
     </div>
 
     <!-- 🔁 Прокручиваемый контент -->
@@ -21,12 +93,12 @@
         Не удалось загрузить товары дня. Попробуйте позже.
       </div>
       <div v-else-if="loading" class="text-center text-gray-400 py-10">Загрузка...</div>
-      <div v-else-if="!finds.length" class="text-center text-gray-500 py-10">
+      <div v-else-if="!displayedFinds.length" class="text-center text-gray-500 py-10">
         Сегодня пока нет новых товаров
       </div>
       <div v-else class="space-y-3">
         <div
-          v-for="f in finds"
+          v-for="f in displayedFinds"
           :key="f.id"
           class="find-card relative bg-[#222227] rounded-2xl px-3 py-3 flex items-center gap-3 shadow-sm"
         >
@@ -73,12 +145,54 @@
 
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { API_BASE } from '../api'
 
 const finds = ref([])
 const loading = ref(true)
 const error = ref(false)
+const categories1 = ref([])
+const categories2 = ref([])
+const selectedCat1 = ref([])
+const selectedCat2 = ref([])
+const showFavOnly = ref(false)
+const filtersOpen = ref(false)
+
+const favoritesCount = computed(() => finds.value.filter(f => f.fav).length)
+const displayedFinds = computed(() =>
+  showFavOnly.value ? finds.value.filter(f => f.fav) : finds.value
+)
+
+function toggleCat1(c) {
+  const idx = selectedCat1.value.indexOf(c)
+  if (idx >= 0) selectedCat1.value.splice(idx, 1)
+  else selectedCat1.value.push(c)
+}
+
+function toggleCat2(c) {
+  const idx = selectedCat2.value.indexOf(c)
+  if (idx >= 0) selectedCat2.value.splice(idx, 1)
+  else selectedCat2.value.push(c)
+}
+
+async function loadCategories1() {
+  try {
+    const r = await fetch(`${API_BASE}/finds/categories1`)
+    if (r.ok) categories1.value = await r.json()
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+async function loadCategories2() {
+  try {
+    const params = selectedCat1.value.join(',')
+    const r = await fetch(`${API_BASE}/finds/categories2?categories1=${encodeURIComponent(params)}`)
+    if (r.ok) categories2.value = await r.json()
+  } catch (e) {
+    console.error(e)
+  }
+}
 
 function formatR(val) {
   if (val === undefined || val === null) return '—'
@@ -89,7 +203,10 @@ async function loadFinds() {
   loading.value = true
   error.value = false
   try {
-    const r = await fetch(`${API_BASE}/finds`)
+    const p1 = selectedCat1.value.join(',')
+    const p2 = selectedCat2.value.join(',')
+    const url = `${API_BASE}/finds?categories1=${encodeURIComponent(p1)}&categories2=${encodeURIComponent(p2)}`
+    const r = await fetch(url)
     if (r.ok) {
       finds.value = (await r.json()).map(f => ({
         ...f,
@@ -103,7 +220,7 @@ async function loadFinds() {
     error.value = true
   } finally {
     loading.value = false
-        if (window.applySafeInsets) window.applySafeInsets()
+    if (window.applySafeInsets) window.applySafeInsets()
   }
 }
 
@@ -132,5 +249,16 @@ async function openSupplier(id) {
   }
 }
 
-onMounted(loadFinds)
+onMounted(() => {
+  loadCategories1()
+  loadCategories2()
+  loadFinds()
+})
+
+watch(selectedCat1, () => {
+  loadCategories2()
+  loadFinds()
+}, { deep: true })
+
+watch(selectedCat2, loadFinds, { deep: true })
 </script>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,8 +53,17 @@ def db_session(client):
             await crud.create_affiliate(db, user.id)
             supplier1 = models.Supplier(name='Store A', contact_link='link')
             supplier2 = models.Supplier(name='Store B', contact_link='link')
-            find = models.Find(name='Item', supplier_id=1, created_at=datetime.utcnow())
-            db.add_all([supplier1, supplier2, find])
+            find1 = models.Find(
+                name='Item 1', supplier_id=1,
+                category1='CatA', category2='BrandX',
+                created_at=datetime.utcnow()
+            )
+            find2 = models.Find(
+                name='Item 2', supplier_id=2,
+                category1='CatB', category2='BrandY',
+                created_at=datetime.utcnow()
+            )
+            db.add_all([supplier1, supplier2, find1, find2])
             await db.commit()
             client.app.state.user_id = user.id
 

--- a/tests/test_finds.py
+++ b/tests/test_finds.py
@@ -2,4 +2,22 @@
 def test_list_finds(client, db_session):
     resp = client.get('/finds')
     assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+    resp = client.get('/finds', params={'categories1': 'CatA'})
+    assert resp.status_code == 200
     assert len(resp.json()) == 1
+
+    resp = client.get('/finds', params={'categories2': 'BrandY'})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+def test_find_categories(client, db_session):
+    resp = client.get('/finds/categories1')
+    assert resp.status_code == 200
+    assert set(resp.json()) == {'CatA', 'CatB'}
+
+    resp = client.get('/finds/categories2', params={'categories1': 'CatA'})
+    assert resp.status_code == 200
+    assert resp.json() == ['BrandX']


### PR DESCRIPTION
## Summary
- extend `Find` model with `category1`/`category2`
- expose new API routes for product categories and filtering
- generate DB migration for new fields
- update CRUD utilities for category filters
- redesign Finds page with same header and filter UI as Suppliers
- seed test data with product categories and expand tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859269ffd28832e9141070463bcffe5