### PR TITLE
Add supplier info modal

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@ import Affiliate from './components/Affiliate.vue';
 import Profile from './components/Profile.vue';
 import ProfileSettings from './components/ProfileSettings.vue';
 import Payment from './components/Payment.vue';
+import SupplierModal from './components/SupplierModal.vue';
 import { userData } from './state';
 import { translations } from './translations.js';
 import { API_BASE } from './api';
@@ -36,6 +37,8 @@ const t = translations.en;
 const currentIndex = ref(pageOrder.indexOf('finds'));
 const sheetVisible = ref(false);
 const sheetLines = ref([]);
+const supplierModalVisible = ref(false);
+const supplierModalData = ref(null);
 const pagesRef = ref(null);
 const innerRef = ref(null);
 const navRef = ref(null);
@@ -68,6 +71,20 @@ function showSheet(lines) {
 
 function hideSheet() {
   sheetVisible.value = false;
+}
+
+function showSupplierModal(data) {
+  supplierModalData.value = data;
+  supplierModalVisible.value = true;
+}
+
+function hideSupplierModal() {
+  supplierModalVisible.value = false;
+  supplierModalData.value = null;
+}
+
+function onLinkCopied() {
+  showSheet('Link copied');
 }
 
 function onNavClick(item) {
@@ -298,6 +315,8 @@ window.applySafeInsets = applySafeInsets;
 window.showPage = showPage;
 window.showSheet = showSheet;
 window.hideSheet = hideSheet;
+window.showSupplierModal = showSupplierModal;
+window.hideSupplierModal = hideSupplierModal;
 
 onMounted(() => {
   if (window.Telegram?.WebApp) {
@@ -312,6 +331,12 @@ onMounted(() => {
 </script>
 <template>
   <Payment v-if="showPayment" @paid="onPaid" />
+  <SupplierModal
+    v-if="supplierModalVisible"
+    :supplier="supplierModalData"
+    @close="hideSupplierModal"
+    @copied="onLinkCopied"
+  />
   <div v-else class="min-h-screen flex flex-col">
     <div ref="pagesRef" class="flex-1 overflow-x-hidden">
       <div ref="innerRef" class="flex h-full " :style="dragStyle">

--- a/src/components/Finds.vue
+++ b/src/components/Finds.vue
@@ -246,19 +246,16 @@ async function toggleFav(f) {
 
 async function openSupplier(id) {
   try {
+    let sData = {}
     const info = await fetch(`${API_BASE}/suppliers/${id}`)
     if (info.ok) {
-      await info.json()
+      sData = await info.json()
     }
     const cont = await fetch(`${API_BASE}/suppliers/${id}/contacts`)
     if (cont.ok) {
       const c = await cont.json()
-      const lines = [
-        `Ссылка: ${c.contact_link || '—'}`,
-        `Телефон: ${c.contact_phone || '—'}`,
-        `Пароль: ${c.contact_password || '—'}`
-      ]
-      if (window.showSheet) window.showSheet(lines)
+      const modalData = { ...sData, ...c }
+      if (window.showSupplierModal) window.showSupplierModal(modalData)
     }
   } catch (e) {
     console.error(e)

--- a/src/components/SupplierModal.vue
+++ b/src/components/SupplierModal.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
+    <div class="bg-[#232226] rounded-2xl p-5 w-[350px] shadow-xl relative">
+      <button class="absolute top-4 right-4 text-white" @click="emitClose">
+        <svg width="20" height="20" fill="none"><path d="M5 5l10 10M15 5L5 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+      </button>
+      <div class="flex items-start mb-4">
+        <img :src="supplier.photo_url" alt="Supplier" class="w-16 h-16 rounded-full object-cover" />
+        <div class="ml-4 flex-1">
+          <div class="text-xl font-bold text-white">{{ supplier.name }}</div>
+          <div class="text-sm text-gray-400">{{ supplier.suppliers_count || 0 }} Suppliers</div>
+        </div>
+        <div class="ml-2 text-purple-400">
+          <svg width="24" height="24" fill="none" :class="supplier.is_favorite ? 'heart-active' : 'heart-inactive'">
+            <path d="M12 21s-5-4.35-8-7.35C1.38 11.02 1.52 7.36 4.22 5.78A5.13 5.13 0 0112 7.25a5.13 5.13 0 017.78-1.47c2.7 1.58 2.84 5.24.22 7.87C17 16.65 12 21 12 21z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
+      </div>
+      <div class="text-sm text-gray-300 mb-4">{{ supplier.description }}</div>
+      <div class="flex flex-wrap gap-x-2 gap-y-1 mb-4">
+        <span v-for="cat in categories" :key="cat" class="text-xs text-purple-400 hover:underline">{{ cat }}</span>
+      </div>
+      <div class="bg-[#1A1A1E] rounded-lg p-3 mb-4">
+        <div class="flex justify-between items-center text-gray-400 text-sm mb-2">
+          <span>Телефон</span>
+          <span class="font-bold text-lg text-white">{{ supplier.contact_phone || '—' }}</span>
+        </div>
+        <div class="flex justify-between items-center text-gray-400 text-sm">
+          <span>Пароль</span>
+          <span class="font-bold text-lg text-white">{{ supplier.contact_password || '—' }}</span>
+        </div>
+      </div>
+      <button @click="copyLink" class="w-full flex items-center justify-center gap-2 bg-[#18181B] text-white rounded-lg py-2 mb-2">
+        <svg width="18" height="18" fill="none"><rect x="3" y="6" width="12" height="6" rx="1" stroke="currentColor" stroke-width="2"/><path d="M7 10v2a1 1 0 001 1h2a1 1 0 001-1v-2" stroke="currentColor" stroke-width="2"/></svg>
+        Скопировать ссылку
+      </button>
+      <a :href="supplier.contact_link || '#'" target="_blank" class="w-full flex items-center justify-center gap-2 bg-[#7A65FC] text-white rounded-lg py-3 font-semibold text-base mt-1">
+        <svg width="20" height="20" fill="none"><path d="M9.5 6.5v-2A1.5 1.5 0 0111 3h6a1.5 1.5 0 011.5 1.5v12A1.5 1.5 0 0117 18h-6a1.5 1.5 0 01-1.5-1.5v-2M5 12h11.5m-8-3l-3 3 3 3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        Перейти на сайт
+      </a>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  supplier: { type: Object, required: true }
+})
+const emit = defineEmits(['close', 'copied'])
+
+const categories = computed(() => [props.supplier.category1, props.supplier.category2].filter(Boolean))
+
+function emitClose() {
+  emit('close')
+}
+
+
+function copyLink() {
+  if (props.supplier.contact_link) {
+    navigator.clipboard?.writeText(props.supplier.contact_link)
+    emit('copied')
+  }
+}
+</script>
+

--- a/src/components/Suppliers.vue
+++ b/src/components/Suppliers.vue
@@ -206,12 +206,8 @@ async function openContacts(s) {
     const r = await fetch(`${API_BASE}/suppliers/${s.id}/contacts`)
     if (r.ok) {
       const data = await r.json()
-      const lines = [
-        `Ссылка: ${data.contact_link || '—'}`,
-        `Телефон: ${data.contact_phone || '—'}`,
-        `Пароль: ${data.contact_password || '—'}`
-      ]
-      if (window.showSheet) window.showSheet(lines)
+      const info = { ...s, ...data }
+      if (window.showSupplierModal) window.showSupplierModal(info)
     }
   } catch (e) {
     console.error(e)


### PR DESCRIPTION
## Summary
- create `SupplierModal.vue` component for displaying supplier details in a modal
- add global modal controls in `App.vue`
- open the modal from Suppliers and Finds pages

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68598012bed4832eb40ffddae1f945b1