### PR TITLE
Fix iOS safe area in full screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ru" class="h-screen">
 <head class="h-screen">
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Telegram Mini App (Vue)</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- support `safe-area-inset-*` on iOS by adding `viewport-fit=cover`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859b6d3e4e4832ea646cf57743e6025