### PR TITLE
Add multi-category support for suppliers

### DIFF
--- a/backend/api/suppliers.py
+++ b/backend/api/suppliers.py
@@ -7,28 +7,22 @@ from ..database import get_db
 router = APIRouter()
 
 
-@router.get('/suppliers/categories1')
-async def get_categories1(db: AsyncSession = Depends(get_db)):
-    return await crud.list_categories1(db)
+@router.get('/suppliers/categories')
+async def get_categories(db: AsyncSession = Depends(get_db)):
+    return await crud.list_categories(db)
 
 
-@router.get('/suppliers/categories2')
-async def get_categories2(categories1: str = '', db: AsyncSession = Depends(get_db)):
-    cats1 = [c.strip() for c in categories1.split(',') if c.strip()]
-    return await crud.list_categories2(db, cats1)
 
 
 @router.get('/suppliers', response_model=list[schemas.SupplierOut])
 async def list_suppliers(
     user_id: int,
-    categories1: str = '',
-    categories2: str = '',
+    categories: str = '',
     favorites_only: bool = False,
     db: AsyncSession = Depends(get_db),
 ):
-    cats1 = [c.strip() for c in categories1.split(',') if c.strip()]
-    cats2 = [c.strip() for c in categories2.split(',') if c.strip()]
-    suppliers = await crud.list_suppliers(db, cats1, cats2)
+    cats = [c.strip() for c in categories.split(',') if c.strip()]
+    suppliers = await crud.list_suppliers(db, cats)
     fav_ids = set(await crud.get_favorite_supplier_ids(db, user_id))
     if favorites_only:
         suppliers = [s for s in suppliers if s.id in fav_ids]

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, BigInteger, String, Date, Boolean, DateTime
+from sqlalchemy import Column, Integer, BigInteger, String, Date, Boolean, DateTime, JSON
 from backend.database import Base
 
 class User(Base):
@@ -39,8 +39,7 @@ class Supplier(Base):
     name = Column(String)
     description = Column(String)
     photo_url = Column(String)
-    category1 = Column(String)
-    category2 = Column(String)
+    categories = Column('category1', JSON)
     contact_link = Column(String)
     contact_phone = Column(String)
     contact_password = Column(String)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -42,8 +42,7 @@ class SupplierBase(BaseModel):
     name: str
     description: str | None = None
     photo_url: str | None = None
-    category1: str | None = None
-    category2: str | None = None
+    categories: list[str] | None = None
 
 
 class SupplierOut(SupplierBase):

--- a/src/components/SupplierModal.vue
+++ b/src/components/SupplierModal.vue
@@ -24,9 +24,8 @@
       <div class="text-xs text-gray-400 mb-2">{{ supplier.suppliers_count || 0 }} Suppliers</div>
       <div class="text-s absolute font-semibold text-gray-400 leading-4">{{ supplier.description }}</div>
       <div class="flex flex-wrap gap-x-1 gap-y-0.5">
-
         <span
-          v-for="cat in categories"
+          v-for="cat in supplier.categories"
           :key="cat"
           class="text-xs text-[#7A65FC] font-medium cursor-pointer hover:underline"
         >{{ cat }}</span>
@@ -87,10 +86,6 @@ const props = defineProps({
   supplier: {
     type: Object,
     required: true,
-  },
-  categories: {
-    type: Array,
-    default: () => [],
   }
 });
 const emitClose = () => emit('close');

--- a/src/components/Suppliers.vue
+++ b/src/components/Suppliers.vue
@@ -54,32 +54,15 @@
             <div class="text-sm mb-1 text-white">Категория</div>
             <div class="flex flex-wrap gap-2">
               <button
-                v-for="c in categories1"
+                v-for="c in categories"
                 :key="c"
-                @click="toggleCat1(c)"
+                @click="toggleCat(c)"
                 :class="[
                   'px-3 py-1 rounded-full text-sm border',
-                  selectedCat1.includes(c) ? 'bg-blue-600 text-white' : 'bg-gray-700 text-white'
+                  selectedCat.includes(c) ? 'bg-blue-600 text-white' : 'bg-gray-700 text-white'
                 ]"
               >
                 {{ c }}
-              </button>
-            </div>
-          </div>
-
-          <div>
-            <div class="text-sm mb-1 text-white">Бренд</div>
-            <div class="flex flex-wrap gap-2">
-              <button
-                v-for="b in categories2"
-                :key="b"
-                @click="toggleCat2(b)"
-                :class="[
-                  'px-3 py-1 rounded-full text-sm border',
-                  selectedCat2.includes(b) ? 'bg-blue-600 text-white' : 'bg-gray-700 text-white'
-                ]"
-              >
-                {{ b }}
               </button>
             </div>
           </div>
@@ -96,6 +79,9 @@
           <div class="flex-1">
             <div class="font-semibold text-white">{{ s.name }}</div>
             <div class="text-sm text-gray-400">{{ s.description }}</div>
+            <div class="flex flex-wrap gap-1 mt-1">
+              <span v-for="cat in s.categories" :key="cat" class="text-xs text-purple-400">{{ cat }}</span>
+            </div>
           </div>
           <!-- Сердце внутри карточки -->
           <button @click="toggleFavorite(s)" class="relative w-6 h-6 mr-3">
@@ -125,10 +111,8 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { userData } from '../state'
 import { API_BASE } from '../api'
 
-const categories1 = ref([])
-const categories2 = ref([])
-const selectedCat1 = ref([])
-const selectedCat2 = ref([])
+const categories = ref([])
+const selectedCat = ref([])
 const suppliers = ref([])
 const showFavOnly = ref(false)
 const filtersOpen = ref(false)
@@ -137,32 +121,16 @@ const favoritesCount = computed(() =>
   suppliers.value.filter(s => s.is_favorite).length
 )
 
-function toggleCat1(c) {
-  const idx = selectedCat1.value.indexOf(c)
-  if (idx >= 0) selectedCat1.value.splice(idx, 1)
-  else selectedCat1.value.push(c)
+function toggleCat(c) {
+  const idx = selectedCat.value.indexOf(c)
+  if (idx >= 0) selectedCat.value.splice(idx, 1)
+  else selectedCat.value.push(c)
 }
 
-function toggleCat2(c) {
-  const idx = selectedCat2.value.indexOf(c)
-  if (idx >= 0) selectedCat2.value.splice(idx, 1)
-  else selectedCat2.value.push(c)
-}
-
-async function loadCategories1() {
+async function loadCategories() {
   try {
-    const r = await fetch(`${API_BASE}/suppliers/categories1`)
-    if (r.ok) categories1.value = await r.json()
-  } catch (e) {
-    console.error(e)
-  }
-}
-
-async function loadCategories2() {
-  try {
-    const params = selectedCat1.value.join(',')
-    const r = await fetch(`${API_BASE}/suppliers/categories2?categories1=${encodeURIComponent(params)}`)
-    if (r.ok) categories2.value = await r.json()
+    const r = await fetch(`${API_BASE}/suppliers/categories`)
+    if (r.ok) categories.value = await r.json()
   } catch (e) {
     console.error(e)
   }
@@ -171,11 +139,10 @@ async function loadCategories2() {
 async function loadSuppliers() {
   if (!userData.user.id) return
   try {
-    const p1 = selectedCat1.value.join(',')
-    const p2 = selectedCat2.value.join(',')
+    const p1 = selectedCat.value.join(',')
     const fav = showFavOnly.value ? 'true' : 'false'
     const uid = userData.user.id
-    const url = `${API_BASE}/suppliers?user_id=${uid}&categories1=${encodeURIComponent(p1)}&categories2=${encodeURIComponent(p2)}&favorites_only=${fav}`
+    const url = `${API_BASE}/suppliers?user_id=${uid}&categories=${encodeURIComponent(p1)}&favorites_only=${fav}`
     const r = await fetch(url)
     if (r.ok) suppliers.value = await r.json()
   } catch (e) {
@@ -215,8 +182,7 @@ async function openContacts(s) {
 }
 
 onMounted(() => {
-  loadCategories1()
-  loadCategories2()
+  loadCategories()
   loadSuppliers()
 })
 
@@ -224,12 +190,7 @@ watch(() => userData.user.id, id => {
   if (id) loadSuppliers()
 })
 
-watch(selectedCat1, () => {
-  loadCategories2()
-  loadSuppliers()
-}, { deep: true })
-
-watch([selectedCat2, showFavOnly], loadSuppliers, { deep: true })
+watch([selectedCat, showFavOnly], loadSuppliers, { deep: true })
 </script>
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,8 +51,8 @@ def db_session(client):
             await db.commit()
             await db.refresh(user)
             await crud.create_affiliate(db, user.id)
-            supplier1 = models.Supplier(name='Store A', contact_link='link')
-            supplier2 = models.Supplier(name='Store B', contact_link='link')
+            supplier1 = models.Supplier(name='Store A', contact_link='link', categories=['CatA', 'CatB'])
+            supplier2 = models.Supplier(name='Store B', contact_link='link', categories=['CatB'])
             find1 = models.Find(
                 name='Item 1', supplier_id=1,
                 category1='CatA', category2='BrandX',

--- a/tests/test_suppliers.py
+++ b/tests/test_suppliers.py
@@ -6,10 +6,17 @@ def test_list_suppliers(client, db_session):
     assert len(resp.json()) == 2
 
 
+def test_supplier_categories(client, db_session):
+    resp = client.get('/suppliers/categories')
+    assert resp.status_code == 200
+    assert set(resp.json()) == {'CatA', 'CatB'}
+
+
 def test_get_supplier(client, db_session):
     resp = client.get('/suppliers/1')
     assert resp.status_code == 200
     assert resp.json()['id'] == 1
+    assert resp.json()['categories'] == ['CatA', 'CatB']
 
 
 def test_get_supplier_not_found(client, db_session):


### PR DESCRIPTION
## Summary
- allow suppliers to store multiple categories
- drop secondary supplier category support
- update suppliers endpoints to use new categories field
- show categories in supplier lists and modal
- adjust tests for new category logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859e2e1fb40832e910f69f52ffa88ff