### PR TITLE
UI tweaks

### DIFF
--- a/src/components/Finds.vue
+++ b/src/components/Finds.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="h-full flex flex-col space-y-1 p-2">
     <!-- 🔒 Фиксированная шапка -->
-    <div class="sticky top-0 z-10 bg-[var(--page-bg-color)] space-y-3 px-3 py-4 border-b border-[#2c2c3a]">
+    <div class="sticky top-0 z-10 bg-[var(--page-bg-color)] space-y-3 px-3 py-4 border-b border-[#2c2c3a] relative overflow-visible">
       <div class="relative flex items-center justify-between">
         <span class="text-lg font-bold text-white">Finds</span>
 
@@ -49,16 +49,19 @@
 
       <!-- Выпадающие фильтры -->
       <transition name="fade">
-        <div v-if="filtersOpen" class="px-1 py-3 bg-[var(--page-bg-color)] space-y-3 border-b border-[#2c2c3a]">
+        <div
+          v-if="filtersOpen"
+          class="absolute left-0 top-full w-full px-1 py-3 bg-[rgba(16,16,17,0.9)] space-y-3 border-b border-[#2c2c3a] z-20"
+        >
           <div>
-            <div class="text-sm mb-1 text-white">Категория</div>
+            <div class="text-xs mb-1 text-white">Категория</div>
             <div class="flex flex-wrap gap-2">
               <button
                 v-for="c in categories1"
                 :key="c"
                 @click="toggleCat1(c)"
                 :class="[
-                  'px-3 py-1 rounded-full text-sm border',
+                  'px-3 py-1 rounded-full text-xs border',
                   selectedCat1.includes(c) ? 'bg-blue-600 text-white' : 'bg-gray-700 text-white'
                 ]"
               >
@@ -68,14 +71,14 @@
           </div>
 
           <div>
-            <div class="text-sm mb-1 text-white">Бренд</div>
+            <div class="text-xs mb-1 text-white">Бренд</div>
             <div class="flex flex-wrap gap-2">
               <button
                 v-for="b in categories2"
                 :key="b"
                 @click="toggleCat2(b)"
                 :class="[
-                  'px-3 py-1 rounded-full text-sm border',
+                  'px-3 py-1 rounded-full text-xs border',
                   selectedCat2.includes(b) ? 'bg-blue-600 text-white' : 'bg-gray-700 text-white'
                 ]"
               >

--- a/src/components/SupplierModal.vue
+++ b/src/components/SupplierModal.vue
@@ -18,7 +18,7 @@
   <!-- Верхняя часть: фото, имя, категории, избранное -->
   <div class="flex items-start relative">
     <img :src="supplier.photo_url" alt="Supplier"
-         class="w-16 h-16 rounded-3xl object-cover border-2 border-[#232226]" />
+         class="w-16 h-16 rounded-full object-cover border-2 border-[#232226]" />
     <div class="ml-3 flex-1">
       <div class="text-lg font-semibold text-white leading-5">{{ supplier.name }}</div>
       <div class="text-xs text-gray-400 mb-2">{{ supplier.suppliers_count || 0 }} Suppliers</div>

--- a/src/components/Suppliers.vue
+++ b/src/components/Suppliers.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="h-full flex flex-col space-y-1 p-2">
     <!-- 🔒 Фиксированная шапка -->
-    <div class="sticky top-0 z-10 bg-[var(--page-bg-color)] space-y-3 px-3 py-4 border-b border-[#2c2c3a]">
+    <div class="sticky top-0 z-10 bg-[var(--page-bg-color)] space-y-3 px-3 py-4 border-b border-[#2c2c3a] relative overflow-visible">
       <div class="relative flex items-center justify-between">
         <span class="text-lg font-bold text-white">Suppliers</span>
 
@@ -49,16 +49,19 @@
 
       <!-- Выпадающие фильтры -->
       <transition name="fade">
-        <div v-if="filtersOpen" class="px-1 py-3 bg-[var(--page-bg-color)] space-y-3 border-b border-[#2c2c3a]">
+        <div
+          v-if="filtersOpen"
+          class="absolute left-0 top-full w-full px-1 py-3 bg-[rgba(16,16,17,0.9)] space-y-3 border-b border-[#2c2c3a] z-20"
+        >
           <div>
-            <div class="text-sm mb-1 text-white">Категория</div>
+            <div class="text-xs mb-1 text-white">Категория</div>
             <div class="flex flex-wrap gap-2">
               <button
                 v-for="c in categories"
                 :key="c"
                 @click="toggleCat(c)"
                 :class="[
-                  'px-3 py-1 rounded-full text-sm border',
+                  'px-3 py-1 rounded-full text-xs border',
                   selectedCat.includes(c) ? 'bg-blue-600 text-white' : 'bg-gray-700 text-white'
                 ]"
               >


### PR DESCRIPTION
## Summary
- make drop-down filters overlay content and semi-transparent
- reduce font size of category items
- use fully round supplier photos

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859ee7a2818832e9a70d3b172f91762