### PR TITLE
Add product badges and price filter

### DIFF
--- a/backend/api/finds.py
+++ b/backend/api/finds.py
@@ -25,11 +25,13 @@ async def list_finds(
     categories1: str = '',
     categories2: str = '',
     favorites_only: bool = False,
+    price_min: int | None = None,
+    price_max: int | None = None,
     db: AsyncSession = Depends(get_db)
 ):
     cats1 = [c.strip() for c in categories1.split(',') if c.strip()]
     cats2 = [c.strip() for c in categories2.split(',') if c.strip()]
-    finds = await crud.list_finds(db, cats1, cats2)
+    finds = await crud.list_finds(db, cats1, cats2, price_min, price_max)
     fav_ids = set()
     if user_id:
         fav_ids = set(await crud.get_favorite_find_ids(db, user_id))

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -212,11 +212,17 @@ async def list_finds(
     db: AsyncSession,
     categories1: list[str] | None = None,
     categories2: list[str] | None = None,
+    price_min: int | None = None,
+    price_max: int | None = None,
 ) -> list[models.Find]:
     stmt = select(models.Find).order_by(models.Find.created_at.desc())
     if categories1:
         stmt = stmt.where(models.Find.category1.in_(categories1))
     if categories2:
         stmt = stmt.where(models.Find.category2.in_(categories2))
+    if price_min is not None:
+        stmt = stmt.where(models.Find.price >= price_min)
+    if price_max is not None:
+        stmt = stmt.where(models.Find.price <= price_max)
     result = await db.execute(stmt)
     return result.scalars().all()

--- a/backend/models.py
+++ b/backend/models.py
@@ -70,3 +70,6 @@ class Find(Base):
     price = Column(Integer)
     supplier_id = Column(Integer, index=True)
     created_at = Column(DateTime)
+    is_hot = Column(Boolean, default=False)
+    is_new = Column(Boolean, default=False)
+    is_high_margin = Column(Boolean, default=False)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -71,5 +71,8 @@ class FindOut(BaseModel):
     supplier_id: int | None = None
     created_at: datetime
     is_favorite: bool | None = None
+    is_hot: bool | None = None
+    is_new: bool | None = None
+    is_high_margin: bool | None = None
 
     model_config = {"from_attributes": True}

--- a/src/components/Finds.vue
+++ b/src/components/Finds.vue
@@ -86,6 +86,17 @@
               </button>
             </div>
           </div>
+
+          <div class="flex gap-2 items-end">
+            <div class="flex flex-col">
+              <label class="text-xs text-white">Цена от</label>
+              <input type="number" v-model.number="priceMin" class="bg-gray-700 text-white text-xs px-2 py-1 rounded" />
+            </div>
+            <div class="flex flex-col">
+              <label class="text-xs text-white">до</label>
+              <input type="number" v-model.number="priceMax" class="bg-gray-700 text-white text-xs px-2 py-1 rounded" />
+            </div>
+          </div>
         </div>
       </transition>
     </div>
@@ -113,7 +124,14 @@
           </div>
 
           <!-- Фото -->
-          <img :src="f.photo_url" alt="" class="w-16 h-16 rounded-xl object-cover bg-[#111]" />
+          <div class="relative">
+            <img :src="f.photo_url" alt="" class="w-16 h-16 rounded-xl object-cover bg-[#111]" />
+            <div class="absolute top-0 right-0 flex gap-0.5 text-[13px]">
+              <span v-if="f.is_hot">🔥</span>
+              <span v-if="f.is_new">🆕</span>
+              <span v-if="f.is_high_margin">💰</span>
+            </div>
+          </div>
 
           <!-- Описание -->
           <div class="flex-1 min-w-0">
@@ -161,6 +179,8 @@ const selectedCat1 = ref([])
 const selectedCat2 = ref([])
 const showFavOnly = ref(false)
 const filtersOpen = ref(false)
+const priceMin = ref(null)
+const priceMax = ref(null)
 
 const favoritesCount = computed(() => finds.value.filter(f => f.fav).length)
 const displayedFinds = computed(() =>
@@ -212,7 +232,9 @@ async function loadFinds() {
     const p2 = selectedCat2.value.join(',')
     const fav = showFavOnly.value ? 'true' : 'false'
     const uid = userData.user.id
-    const url = `${API_BASE}/finds?user_id=${uid}&categories1=${encodeURIComponent(p1)}&categories2=${encodeURIComponent(p2)}&favorites_only=${fav}`
+    let url = `${API_BASE}/finds?user_id=${uid}&categories1=${encodeURIComponent(p1)}&categories2=${encodeURIComponent(p2)}&favorites_only=${fav}`
+    if (priceMin.value !== null) url += `&price_min=${priceMin.value}`
+    if (priceMax.value !== null) url += `&price_max=${priceMax.value}`
     const r = await fetch(url)
     if (r.ok) {
       finds.value = (await r.json()).map(f => ({
@@ -285,4 +307,5 @@ watch(selectedCat1, () => {
 }, { deep: true })
 
 watch([selectedCat2, showFavOnly], loadFinds, { deep: true })
+watch([priceMin, priceMax], loadFinds)
 </script>

--- a/src/components/ItemModal.vue
+++ b/src/components/ItemModal.vue
@@ -11,19 +11,16 @@
           alt="Item"
           class="w-[185px] h-[185px] object-contain border border-[#232226] bg-[#232226]"
         />
-        <span
-          v-if="item.is_new"
-          class="absolute top-3 left-3 bg-[#406AFF] text-white text-xs font-semibold px-2 py-0.5 rounded-md shadow-[0_2px_8px_rgba(36,106,255,0.23)]"
-        >NEW</span>
-        <button
-          class="absolute top-3 right-3"
-          @click="toggleFav"
-        >
-          <svg
-            width="28"
-            height="28"
-            fill="none"
-            :class="item.fav ? 'text-[#7A65FC]' : 'text-[#7367D0]'"
+        <div class="absolute top-3 right-3 flex gap-1 text-xl items-center">
+          <span v-if="item.is_hot">🔥</span>
+          <span v-if="item.is_new">🆕</span>
+          <span v-if="item.is_high_margin">💰</span>
+          <button class="ml-1" @click="toggleFav">
+            <svg
+              width="28"
+              height="28"
+              fill="none"
+              :class="item.fav ? 'text-[#7A65FC]' : 'text-[#7367D0]'"
           >
             <path
               d="M14 24s-5.6-4.87-9-8.22C2.07 13.22 2.22 9.29 5.26 7.42A5.77 5.77 0 0114 8.85a5.77 5.77 0 018.74-1.43c3.04 1.87 3.19 5.8.26 8.36C19.6 19.13 14 24 14 24z"
@@ -34,8 +31,8 @@
               :fill="item.fav ? 'currentColor' : 'none'"
             />
           </svg>
-        </button>
-      </div>
+          </button>
+        </div>
       <div class="text-center mb-1">
         <div class="text-xl font-extrabold text-white leading-6">{{ item.name }}</div>
         <div class="text-xs text-[#A4A4A8] mt-1 mb-1 leading-snug">{{ item.desc }}</div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,11 +56,13 @@ def db_session(client):
             find1 = models.Find(
                 name='Item 1', supplier_id=1,
                 category1='CatA', category2='BrandX',
+                price=100,
                 created_at=datetime.utcnow()
             )
             find2 = models.Find(
                 name='Item 2', supplier_id=2,
                 category1='CatB', category2='BrandY',
+                price=200,
                 created_at=datetime.utcnow()
             )
             db.add_all([supplier1, supplier2, find1, find2])

--- a/tests/test_finds.py
+++ b/tests/test_finds.py
@@ -12,6 +12,11 @@ def test_list_finds(client, db_session):
     assert resp.status_code == 200
     assert len(resp.json()) == 1
 
+    resp = client.get('/finds', params={'price_min': 150})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+    assert resp.json()[0]['name'] == 'Item 2'
+
 
 def test_find_categories(client, db_session):
     resp = client.get('/finds/categories1')


### PR DESCRIPTION
## Summary
- support `is_hot`, `is_new` and `is_high_margin` fields for finds
- add price range query params to `/finds`
- overlay new product badges on item images
- provide price filter inputs on the Find page
- show badges in item modal
- test price filter logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f236fedc832e8d0ee97209e7e44d