### PR TITLE
Add favorites count for suppliers

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -144,6 +144,25 @@ async def get_favorite_supplier_ids(db: AsyncSession, user_id: int) -> list[int]
     return [r for r in result.scalars().all()]
 
 
+async def get_supplier_favorites_count(db: AsyncSession, supplier_id: int) -> int:
+    result = await db.execute(
+        select(func.count(models.FavoriteSupplier.id)).where(
+            models.FavoriteSupplier.supplier_id == supplier_id
+        )
+    )
+    return result.scalar_one()
+
+
+async def get_all_favorites_count(db: AsyncSession) -> dict[int, int]:
+    result = await db.execute(
+        select(
+            models.FavoriteSupplier.supplier_id,
+            func.count(models.FavoriteSupplier.id)
+        ).group_by(models.FavoriteSupplier.supplier_id)
+    )
+    return {sid: cnt for sid, cnt in result.all()}
+
+
 async def toggle_favorite_supplier(db: AsyncSession, user_id: int, supplier_id: int) -> bool:
     result = await db.execute(
         select(models.FavoriteSupplier).where(

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -48,6 +48,7 @@ class SupplierBase(BaseModel):
 class SupplierOut(SupplierBase):
     id: int
     is_favorite: bool | None = None
+    favorites_count: int | None = None
 
     model_config = {"from_attributes": True}
 

--- a/src/components/SupplierModal.vue
+++ b/src/components/SupplierModal.vue
@@ -22,7 +22,7 @@
               <div class="flex items-center justify-between">
                 <div>
                   <div class="text-lg font-bold text-white leading-5">{{ supplier.name }}</div>
-                  <div class="text-xs text-gray-400 mt-0.5 mb-1">{{ supplier.suppliers_count || 0 }} Suppliers</div>
+                  <div class="text-xs text-gray-400 mt-0.5 mb-1">Избрали {{ supplier.favorites_count || 0 }}</div>
                 </div>
                 <button @click="toggleFavorite">
                   <svg width="24" height="24" fill="none"

--- a/src/components/Suppliers.vue
+++ b/src/components/Suppliers.vue
@@ -94,7 +94,7 @@
         <div class="font-semibold text-white text-lg leading-tight truncate">{{ s.name }}</div>
 
       </div>
-      <div class="text-xs text-gray-400 mt-0.5">{{ s.suppliers_count }} suppliers</div>
+      <div class="text-xs text-gray-400 mt-0.5">Избрали {{ s.favorites_count || 0 }}</div>
       <div class="text-sm text-gray-400 mt-1 truncate">{{ s.description }}</div>
       <div class="flex flex-wrap gap-x-2 gap-y-0.5 mt-2">
         <span
@@ -192,6 +192,11 @@ async function toggleFavorite(s) {
     if (r.ok) {
       const data = await r.json()
       s.is_favorite = data.favorite
+      if (data.favorite) {
+        s.favorites_count = (s.favorites_count || 0) + 1
+      } else {
+        s.favorites_count = Math.max(0, (s.favorites_count || 1) - 1)
+      }
     }
   } catch (e) {
     console.error(e)

--- a/tests/test_suppliers.py
+++ b/tests/test_suppliers.py
@@ -3,7 +3,10 @@ def test_list_suppliers(client, db_session):
     uid = client.app.state.user_id
     resp = client.get('/suppliers', params={'user_id': uid})
     assert resp.status_code == 200
-    assert len(resp.json()) == 2
+    data = resp.json()
+    assert len(data) == 2
+    assert all('favorites_count' in s for s in data)
+    assert all(s['favorites_count'] == 0 for s in data)
 
 
 def test_supplier_categories(client, db_session):
@@ -17,6 +20,7 @@ def test_get_supplier(client, db_session):
     assert resp.status_code == 200
     assert resp.json()['id'] == 1
     assert resp.json()['categories'] == ['CatA', 'CatB']
+    assert resp.json()['favorites_count'] == 0
 
 
 def test_get_supplier_not_found(client, db_session):
@@ -35,6 +39,9 @@ def test_toggle_favorite(client, db_session):
     resp = client.post('/suppliers/1/favorite', json={'user_id': uid})
     assert resp.status_code == 200
     assert resp.json()['favorite'] is True
+    resp_detail = client.get('/suppliers/1')
+    assert resp_detail.status_code == 200
+    assert resp_detail.json()['favorites_count'] == 1
     # Should now show only one supplier when favorites_only is true
     resp2 = client.get('/suppliers', params={'user_id': uid, 'favorites_only': True})
     assert resp2.status_code == 200


### PR DESCRIPTION
## Summary
- show how many users added a supplier to favourites
- expose favourites count via API
- test new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a8cf5d314832eb8cc94e313bb9697