### PR TITLE
Unify card styles with supplier design

### DIFF
--- a/src/components/Affiliate.vue
+++ b/src/components/Affiliate.vue
@@ -14,7 +14,7 @@
       </div>
     </div>
     <!-- Карточка профиля -->
-    <div class="bg-[#191919] border border-[#42424280] rounded-[10px] px-5 py-4">
+    <div class="card-base px-5 py-4">
       <div class="flex justify-between items-center">
         <div>
           <div class="font-bold text-base text-[#DFDFDF]">{{ nickname || '—' }}</div>
@@ -57,7 +57,7 @@
     </div>
 
     <!-- Детальная статистика -->
-    <div class="bg-[#191919] border border-[#42424280] rounded-[10px] px-5 py-5 space-y-3">
+    <div class="card-base px-5 py-5 space-y-3">
       <div class="flex justify-between text-sm">
         <span class="text-[#FFFFFFBF] font-medium">Приглашено пользователей</span>
         <span class="font-extrabold text-[#DFDFDF]">{{ stats.invited ?? '—' }}</span>
@@ -103,7 +103,7 @@
     </div>
 
     <!-- Ссылка и копирование -->
-    <div class="bg-[#191919] border border-[#292929] rounded-[10px] px-5 py-3 flex flex-col gap-2">
+    <div class="card-base px-5 py-3 flex flex-col gap-2">
       <div class="flex items-center gap-2">
         <span class="font-semibold text-[#DFDFDF] text-sm">Твоя реферальная ссылка</span>
         <button @click="copyLink" class="w-20 h-20 flex items-center justify-center">
@@ -125,7 +125,7 @@
     </div>
 
     <!-- Рекламные материалы -->
-    <div class="bg-[#191919] border border-[#292929] rounded-[10px] px-5 py-3">
+    <div class="card-base px-5 py-3">
       <div class="flex items-center gap-2">
         <svg fill="currentColor" class="w-4 h-4 text-[#8B81F5]">
           <circle cx="8" cy="8" r="8"/>

--- a/src/components/Feed.vue
+++ b/src/components/Feed.vue
@@ -16,7 +16,7 @@
     </div>
 
      <!-- 🛠️ Блок "в разработке" -->
-    <div class="flex flex-1 mx-2 items-center justify-center text-center bg-[#222227] rounded-2xl">
+    <div class="card-base flex flex-1 mx-2 items-center justify-center text-center">
 
       <div class="flex flex-col items-center space-y-4 max-w-xs">
         <!-- Эмодзи или картинка -->

--- a/src/components/Finds.vue
+++ b/src/components/Finds.vue
@@ -117,7 +117,7 @@
         <div
           v-for="f in displayedFinds"
           :key="f.id"
-          class="find-card relative bg-[#222227] rounded-2xl px-3 py-3 flex items-center gap-3 shadow-sm"
+          class="find-card card-base relative px-3 py-3 flex items-center gap-3 shadow-sm"
         >
           <!-- Статус -->
           <div v-if="f.badge" class="absolute left-2 top-2 z-10">

--- a/src/components/Profile.vue
+++ b/src/components/Profile.vue
@@ -13,7 +13,7 @@
       </div>
     </div>
     <div class="relative p-4 space-y-4 overflow-hidden flex-1">
-      <div class="bg-gray-800 p-4 rounded text-center">
+      <div class="card-base p-4 text-center">
         <div class="avatar mx-auto mb-3">
           <span class="num">{{ numDisplay }}</span>
         </div>
@@ -22,7 +22,7 @@
         <div>{{ t.location }}: {{ user.location || '—' }}</div>
         <div>{{ t.status }}: {{ user.status || '—' }}</div>
       </div>
-      <div class="bg-gray-800 p-4 rounded">
+      <div class="card-base p-4">
         <h3 class="text-lg font-bold mb-2">{{ t.aboutClub }}</h3>
         <p>Клуб единомышленников, где агенты обмениваются опытом и секретами эффективных продаж. Присоединяйся и расширяй свои возможности.</p>
       </div>

--- a/src/style.css
+++ b/src/style.css
@@ -38,6 +38,13 @@ body {
   padding-bottom: calc(70px + env(safe-area-inset-bottom)); /* nav height + безопасный отступ */
 
 }
+
+/* Общий стиль карточек, как на странице поставщиков */
+.card-base {
+  background-color: #191919;
+  border: 1px solid #424242;
+  border-radius: 0.75rem;
+}
 .safe-area {
   padding-top: env(safe-area-inset-top);
   padding-bottom: env(safe-area-inset-top);
@@ -190,7 +197,9 @@ nav.show-labels .nav-label {
 /*  height: 100%; !* ✅ фикс *!*/
 /*}*/
 .find-card {
-  border: 1.5px solid #242434;
+  background-color: #191919;
+  border: 1px solid #424242;
+  border-radius: 0.75rem;
   box-shadow: 0 2px 12px 0 #18192733;
 }
 .like-btn {


### PR DESCRIPTION
## Summary
- add shared `card-base` style for dark cards
- update Find card style to match supplier design
- apply new card style to Feed, Affiliate, Profile pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b57c3416c832eadffaf2e8bce9dca