### PR TITLE
Show favorites count for finds

### DIFF
--- a/backend/api/finds.py
+++ b/backend/api/finds.py
@@ -33,6 +33,7 @@ async def list_finds(
     brands_list = [c.strip() for c in brands.split(',') if c.strip()]
     finds = await crud.list_finds(db, cats, brands_list, price_min, price_max)
     fav_ids = set()
+    fav_counts = await crud.get_all_find_favorites_count(db)
     if user_id:
         fav_ids = set(await crud.get_favorite_find_ids(db, user_id))
         if favorites_only:
@@ -42,6 +43,7 @@ async def list_finds(
         item = schemas.FindOut.model_validate(f)
         if user_id:
             item.is_favorite = f.id in fav_ids
+        item.favorites_count = fav_counts.get(f.id, 0)
         result.append(item)
     return result
 

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -208,6 +208,25 @@ async def toggle_favorite_find(db: AsyncSession, user_id: int, find_id: int) -> 
         return True
 
 
+async def get_find_favorites_count(db: AsyncSession, find_id: int) -> int:
+    result = await db.execute(
+        select(func.count(models.FavoriteFind.id)).where(
+            models.FavoriteFind.find_id == find_id
+        )
+    )
+    return result.scalar_one()
+
+
+async def get_all_find_favorites_count(db: AsyncSession) -> dict[int, int]:
+    result = await db.execute(
+        select(
+            models.FavoriteFind.find_id,
+            func.count(models.FavoriteFind.id)
+        ).group_by(models.FavoriteFind.find_id)
+    )
+    return {fid: cnt for fid, cnt in result.all()}
+
+
 async def get_supplier(db: AsyncSession, supplier_id: int) -> models.Supplier | None:
     result = await db.execute(select(models.Supplier).where(models.Supplier.id == supplier_id))
     return result.scalar_one_or_none()

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -72,6 +72,7 @@ class FindOut(BaseModel):
     price: int | None = None
     created_at: datetime
     is_favorite: bool | None = None
+    favorites_count: int | None = None
     is_hot: bool | None = None
     is_new: bool | None = None
     is_high_margin: bool | None = None

--- a/src/App.vue
+++ b/src/App.vue
@@ -111,6 +111,11 @@ async function onItemToggleFavorite() {
     if (r.ok) {
       const data = await r.json();
       item.fav = data.favorite;
+      if (data.favorite) {
+        item.favorites_count = (item.favorites_count || 0) + 1;
+      } else {
+        item.favorites_count = Math.max(0, (item.favorites_count || 1) - 1);
+      }
     }
   } catch (e) {
     console.error(e);

--- a/src/components/Finds.vue
+++ b/src/components/Finds.vue
@@ -271,6 +271,11 @@ async function toggleFav(f) {
     if (r.ok) {
       const data = await r.json()
       f.fav = data.favorite
+      if (data.favorite) {
+        f.favorites_count = (f.favorites_count || 0) + 1
+      } else {
+        f.favorites_count = Math.max(0, (f.favorites_count || 1) - 1)
+      }
     }
   } catch (e) {
     console.error(e)

--- a/tests/test_finds.py
+++ b/tests/test_finds.py
@@ -2,7 +2,10 @@
 def test_list_finds(client, db_session):
     resp = client.get('/finds')
     assert resp.status_code == 200
-    assert len(resp.json()) == 2
+    data = resp.json()
+    assert len(data) == 2
+    assert all('favorites_count' in f for f in data)
+    assert all(f['favorites_count'] == 0 for f in data)
 
     resp = client.get('/finds', params={'categories': 'CatA'})
     assert resp.status_code == 200
@@ -33,6 +36,11 @@ def test_toggle_find_favorite(client, db_session):
     resp = client.post('/finds/1/favorite', json={'user_id': uid})
     assert resp.status_code == 200
     assert resp.json()['favorite'] is True
+
+    resp_all = client.get('/finds')
+    assert resp_all.status_code == 200
+    counts = {f['id']: f['favorites_count'] for f in resp_all.json()}
+    assert counts.get(1) == 1
 
     resp2 = client.get('/finds', params={'user_id': uid, 'favorites_only': True})
     assert resp2.status_code == 200


### PR DESCRIPTION
## Summary
- add favorites_count field to `FindOut` schema
- expose find favorites counts in the API
- update CRUD helpers for find favorites counts
- update frontend to adjust favorites count when toggling favorites
- extend tests to verify favorites count for finds

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba72729a4832ead68234894a93e09