### PR TITLE
Remove server-side category filtering

### DIFF
--- a/backend/api/finds.py
+++ b/backend/api/finds.py
@@ -22,16 +22,10 @@ async def get_brands(categories: str = '', db: AsyncSession = Depends(get_db)):
 @router.get('/finds', response_model=list[schemas.FindOut])
 async def list_finds(
     user_id: int | None = None,
-    categories: str = '',
-    brands: str = '',
     favorites_only: bool = False,
-    price_min: int | None = None,
-    price_max: int | None = None,
     db: AsyncSession = Depends(get_db)
 ):
-    cats = [c.strip() for c in categories.split(',') if c.strip()]
-    brands_list = [c.strip() for c in brands.split(',') if c.strip()]
-    finds = await crud.list_finds(db, cats, brands_list, price_min, price_max)
+    finds = await crud.list_finds(db)
     fav_ids = set()
     fav_counts = await crud.get_all_find_favorites_count(db)
     if user_id:

--- a/backend/api/suppliers.py
+++ b/backend/api/suppliers.py
@@ -17,12 +17,10 @@ async def get_categories(db: AsyncSession = Depends(get_db)):
 @router.get('/suppliers', response_model=list[schemas.SupplierOut])
 async def list_suppliers(
     user_id: int,
-    categories: str = '',
     favorites_only: bool = False,
     db: AsyncSession = Depends(get_db),
 ):
-    cats = [c.strip() for c in categories.split(',') if c.strip()]
-    suppliers = await crud.list_suppliers(db, cats)
+    suppliers = await crud.list_suppliers(db)
     fav_ids = set(await crud.get_favorite_supplier_ids(db, user_id))
     fav_counts = await crud.get_all_favorites_count(db)
     if favorites_only:

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -125,16 +125,9 @@ async def list_categories(db: AsyncSession) -> list[str]:
 
 async def list_suppliers(
     db: AsyncSession,
-    categories: list[str] | None = None,
 ) -> list[models.Supplier]:
     result = await db.execute(select(models.Supplier))
-    suppliers = result.scalars().all()
-    if categories:
-        suppliers = [
-            s for s in suppliers
-            if s.categories and any(c in s.categories for c in categories)
-        ]
-    return suppliers
+    return result.scalars().all()
 
 
 async def get_favorite_supplier_ids(db: AsyncSession, user_id: int) -> list[int]:
@@ -248,19 +241,7 @@ async def list_find_brands(db: AsyncSession, categories: list[str] | None = None
 
 async def list_finds(
     db: AsyncSession,
-    categories: list[str] | None = None,
-    brands: list[str] | None = None,
-    price_min: int | None = None,
-    price_max: int | None = None,
 ) -> list[models.Find]:
     stmt = select(models.Find).order_by(models.Find.created_at.desc())
-    if categories:
-        stmt = stmt.where(models.Find.category.in_(categories))
-    if brands:
-        stmt = stmt.where(models.Find.brand.in_(brands))
-    if price_min is not None:
-        stmt = stmt.where(models.Find.price >= price_min)
-    if price_max is not None:
-        stmt = stmt.where(models.Find.price <= price_max)
     result = await db.execute(stmt)
     return result.scalars().all()

--- a/tests/test_finds.py
+++ b/tests/test_finds.py
@@ -7,18 +7,6 @@ def test_list_finds(client, db_session):
     assert all('favorites_count' in f for f in data)
     assert all(f['favorites_count'] == 0 for f in data)
 
-    resp = client.get('/finds', params={'categories': 'CatA'})
-    assert resp.status_code == 200
-    assert len(resp.json()) == 1
-
-    resp = client.get('/finds', params={'brands': 'BrandY'})
-    assert resp.status_code == 200
-    assert len(resp.json()) == 1
-
-    resp = client.get('/finds', params={'price_min': 150})
-    assert resp.status_code == 200
-    assert len(resp.json()) == 1
-    assert resp.json()[0]['name'] == 'Item 2'
 
 
 def test_find_categories(client, db_session):


### PR DESCRIPTION
## Summary
- filter products by category on the client
- drop unused filtering code for suppliers and finds
- update tests accordingly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc185f9a0832eaf2f1d263b140c8d