### PR TITLE
Add range slider for price filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@tailwindcss/vite": "^4.1.10",
         "tailwindcss": "^4.1.10",
         "vite": "^6.3.5",
-        "vue": "^3.5.17"
+        "vue": "^3.5.17",
+        "vue-slider-component": "^3.2.24"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.2.4"
@@ -1188,6 +1189,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.43.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
+      "integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -1843,6 +1855,37 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-property-decorator": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-8.5.1.tgz",
+      "integrity": "sha512-O6OUN2OMsYTGPvgFtXeBU3jPnX5ffQ9V4I1WfxFQ6dqz6cOUbR3Usou7kgFpfiXDvV7dJQSFcJ5yUPgOtPPm1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "vue-class-component": "^7.1.0"
+      },
+      "peerDependencies": {
+        "vue": "*"
+      }
+    },
+    "node_modules/vue-property-decorator/node_modules/vue-class-component": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.2.6.tgz",
+      "integrity": "sha512-+eaQXVrAm/LldalI272PpDe3+i4mPis0ORiMYxF6Ae4hyuCh15W8Idet7wPUEs4N4YptgFHGys4UrgNQOMyO6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^2.0.0"
+      }
+    },
+    "node_modules/vue-slider-component": {
+      "version": "3.2.24",
+      "resolved": "https://registry.npmjs.org/vue-slider-component/-/vue-slider-component-3.2.24.tgz",
+      "integrity": "sha512-28hfotAL/CPXPwqHgVFyUwUEV0zweoc2wW0bgraGkoIcRZGlFjk8caYJLE8+Luug5t3b9tJm/NyDXpyIdmcYZg==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js": "^3.6.5",
+        "vue-property-decorator": "^8.0.0"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@tailwindcss/vite": "^4.1.10",
     "tailwindcss": "^4.1.10",
     "vite": "^6.3.5",
-    "vue": "^3.5.17"
+    "vue": "^3.5.17",
+    "vue-slider-component": "^3.2.24"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.4"

--- a/src/components/Finds.vue
+++ b/src/components/Finds.vue
@@ -54,14 +54,20 @@
     class="absolute left-0 top-full w-full px-1 py-3 bg-[rgba(16,16,17,0.9)] space-y-3 border-b border-[#2c2c3a] z-20 max-h-[50vh] overflow-y-auto scrollbar-hide"
   >
     <!-- Цена -->
-    <div class="flex gap-2">
-      <div class="flex flex-col flex-1">
-        <label class="text-xs text-white">Цена от</label>
-        <input type="number" v-model.number="priceMin" class="bg-gray-700 text-white text-xs px-2 py-1 rounded" /></div>
-      <div class="flex flex-col flex-1">
-        <label class="text-xs text-white">до</label>
-        <input type="number" v-model.number="priceMax" class="bg-gray-700 text-white text-xs px-2 py-1 rounded" />
+    <div>
+      <div class="text-xs text-white text-center mb-1">
+        {{ formatR(priceRange[0]) }} — {{ formatR(priceRange[1]) }}
       </div>
+      <VueSlider
+        v-model="priceRange"
+        :min="minPrice"
+        :max="maxPrice"
+        :lazy="true"
+        :dot-size="16"
+        :enable-cross="false"
+        :tooltip="'none'"
+        class="px-2"
+      />
     </div>
 
     <!-- Категории -->
@@ -175,6 +181,8 @@
 
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
+import VueSlider from 'vue-slider-component'
+import 'vue-slider-component/theme/default.css'
 import { userData } from '../state'
 import { API_BASE } from '../api'
 
@@ -187,8 +195,10 @@ const selectedCategories = ref([])
 const selectedBrands = ref([])
 const showFavOnly = ref(false)
 const filtersOpen = ref(false)
-const priceMin = ref(null)
-const priceMax = ref(null)
+const minPrice = ref(0)
+const maxPrice = ref(0)
+const priceRange = ref([0, 0])
+const debouncedRange = ref([0, 0])
 
 const favoritesCount = computed(() => finds.value.filter(f => f.fav).length)
 const displayedFinds = computed(() => {
@@ -202,11 +212,11 @@ const displayedFinds = computed(() => {
   if (selectedBrands.value.length) {
     items = items.filter(f => selectedBrands.value.includes(f.brand))
   }
-  if (priceMin.value !== null) {
-    items = items.filter(f => f.price >= priceMin.value)
+  if (debouncedRange.value[0] !== null) {
+    items = items.filter(f => f.price >= debouncedRange.value[0])
   }
-  if (priceMax.value !== null) {
-    items = items.filter(f => f.price <= priceMax.value)
+  if (debouncedRange.value[1] !== null) {
+    items = items.filter(f => f.price <= debouncedRange.value[1])
   }
   return items
 })
@@ -264,6 +274,15 @@ async function loadFinds() {
         fav: f.is_favorite || false,
         badge: f.badge || null
       }))
+      const prices = finds.value
+        .map(f => f.price)
+        .filter(p => typeof p === 'number')
+      if (prices.length) {
+        minPrice.value = Math.min(...prices)
+        maxPrice.value = Math.max(...prices)
+        priceRange.value = [minPrice.value, maxPrice.value]
+        debouncedRange.value = priceRange.value.slice()
+      }
       updateCategories()
       updateBrands()
     } else {
@@ -327,6 +346,14 @@ onMounted(() => {
 watch(() => userData.user.id, id => {
   if (id) loadFinds()
 })
+
+let rangeTimer = null
+watch(priceRange, (val) => {
+  clearTimeout(rangeTimer)
+  rangeTimer = setTimeout(() => {
+    debouncedRange.value = val.slice()
+  }, 300)
+}, { deep: true })
 
 watch(selectedCategories, () => {
   updateBrands()


### PR DESCRIPTION
## Summary
- add `vue-slider-component` dependency
- replace price input fields with a range slider
- compute price bounds from all items
- debounce item filtering when price range changes

## Testing
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_685bdf749b34832ea66d45b0de2c21c2