### PR TITLE
Add subscription payment modal and API endpoint

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -2,3 +2,4 @@ from .users import router as users_router
 from .affiliate import router as affiliate_router
 from .suppliers import router as suppliers_router
 from .finds import router as finds_router
+from .payments import router as payments_router

--- a/backend/api/payments.py
+++ b/backend/api/payments.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+class PaymentRequest(BaseModel):
+    user_id: int
+    months: int
+
+class PaymentResponse(BaseModel):
+    payment_url: str
+
+@router.post('/payments/membership', response_model=PaymentResponse)
+async def create_membership_payment(data: PaymentRequest):
+    # In a real application this would create a payment in an external system
+    url = f"https://pay.example.com/?user={data.user_id}&months={data.months}"
+    return PaymentResponse(payment_url=url)

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from backend import models
-from backend.api import affiliate_router, finds_router, suppliers_router, users_router
+from backend.api import affiliate_router, finds_router, suppliers_router, users_router, payments_router
 from backend.config import get_settings
 from backend.database import engine
 from backend.api.auth import router as auth_router
@@ -29,3 +29,4 @@ app.include_router(users_router)
 app.include_router(affiliate_router)
 app.include_router(suppliers_router)
 app.include_router(finds_router)
+app.include_router(payments_router)

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,6 +16,7 @@ import NewUserProfile from './components/NewUserProfile.vue';
 import SupplierModal from './components/SupplierModal.vue';
 import ItemModal from './components/ItemModal.vue';
 import ProfileSettings from './components/ProfileSettings.vue';
+import MembershipModal from './components/MembershipModal.vue';
 import { userData } from './state';
 import { translations } from './translations.js';
 import { API_BASE } from './api';
@@ -44,6 +45,7 @@ const supplierModalData = ref(null);
 const itemModalVisible = ref(false);
 const itemModalData = ref(null);
 const settingsModalVisible = ref(false);
+const membershipModalVisible = ref(false);
 const pagesRef = ref(null);
 const innerRef = ref(null);
 const navRef = ref(null);
@@ -108,6 +110,14 @@ function showSettingsModal() {
 
 function hideSettingsModal() {
   settingsModalVisible.value = false;
+}
+
+function showMembershipModal() {
+  membershipModalVisible.value = true;
+}
+
+function hideMembershipModal() {
+  membershipModalVisible.value = false;
 }
 
 async function onItemToggleFavorite() {
@@ -421,6 +431,8 @@ window.showItemModal = showItemModal;
 window.hideItemModal = hideItemModal;
 window.showSettingsModal = showSettingsModal;
 window.hideSettingsModal = hideSettingsModal;
+window.showMembershipModal = showMembershipModal;
+window.hideMembershipModal = hideMembershipModal;
 
 function updateNavForKeyboard() {
   const viewport = window.visualViewport;
@@ -487,6 +499,10 @@ onMounted(() => {
     @close="hideItemModal"
     @copied="onLinkCopied"
     @toggle-favorite="onItemToggleFavorite"
+  />
+  <MembershipModal
+    v-if="membershipModalVisible"
+    @close="hideMembershipModal"
   />
   <div class="min-h-screen flex flex-col overflow-hidden">
     <div ref="pagesRef" class="flex-1 overflow-x-hidden">

--- a/src/components/MembershipModal.vue
+++ b/src/components/MembershipModal.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+    <div class="w-full px-1 mx-1 absolute bottom-32">
+      <div class="bg-[var(--page-bg-color)] w-full rounded-2xl shadow-2xl pt-0 pb-5 px-3 overflow-hidden mx-0">
+        <div class="flex items-center justify-between px-5 pt-4 pb-3">
+          <span class="text-base text-white font-medium w-1/3 text-left">&nbsp;</span>
+          <span class="text-base text-white font-medium w-1/3 text-center">Оплата</span>
+          <button class="w-1/3 flex justify-end" @click="emitClose">
+            <svg width="22" height="22" fill="none">
+              <path d="M5 5l12 12M17 5L5 17" stroke="white" stroke-width="2" stroke-linecap="round" />
+            </svg>
+          </button>
+        </div>
+        <div class="space-y-3 px-4">
+          <div v-for="opt in options" :key="opt.months" class="flex items-center text-white">
+            <input type="radio" :value="opt" v-model="selected" class="mr-2" />
+            <label>{{ opt.months }} мес – {{ formatPrice(opt.price) }}</label>
+          </div>
+          <button
+            v-if="!paymentUrl"
+            @click="confirm"
+            class="rounded-xl bg-[var(--button-color)] w-full h-10 mt-2 flex items-center justify-center gap-2 text-white text-base shadow"
+          >
+            Подтвердить
+          </button>
+          <a
+            v-if="paymentUrl"
+            :href="paymentUrl"
+            target="_blank"
+            class="rounded-xl bg-[var(--button-color)] w-full h-10 mt-2 flex items-center justify-center gap-2 text-white text-base shadow"
+          >
+            Оплатить
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { API_BASE } from '../api'
+import { userData } from '../state'
+
+const emit = defineEmits(['close'])
+
+const options = [
+  { months: 1, price: 1990 },
+  { months: 3, price: 4990 },
+  { months: 6, price: 9990 },
+  { months: 12, price: 19990 }
+]
+
+const selected = ref(options[0])
+const paymentUrl = ref('')
+
+function emitClose() {
+  emit('close')
+}
+
+function formatPrice(p) {
+  return new Intl.NumberFormat('ru-RU').format(p) + ' ₽'
+}
+
+async function confirm() {
+  try {
+    const resp = await fetch(`${API_BASE}/payments/membership`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: userData.user.id, months: selected.value.months })
+    })
+    if (resp.ok) {
+      const data = await resp.json()
+      paymentUrl.value = data.payment_url
+    }
+  } catch (e) {
+    console.error(e)
+  }
+}
+</script>

--- a/src/components/NewUser.vue
+++ b/src/components/NewUser.vue
@@ -22,20 +22,13 @@
 </template>
 
 <script setup>
-import { userData } from '../state'
-import { API_BASE } from '../api'
 import { onMounted } from 'vue'
 
 const emit = defineEmits(['paid'])
 
-async function pay() {
-  if (!userData.user.id) return
-  try {
-    await fetch(`${API_BASE}/users/${userData.user.id}/pay`, { method: 'POST' })
-    userData.user.is_member = true
-    emit('paid')
-  } catch (e) {
-    console.error(e)
+function pay() {
+  if (window.showMembershipModal) {
+    window.showMembershipModal();
   }
 }
 

--- a/src/components/NewUserProfile.vue
+++ b/src/components/NewUserProfile.vue
@@ -23,20 +23,13 @@
 </template>
 
 <script setup>
-import { userData } from '../state'
-import { API_BASE } from '../api'
 import { onMounted } from 'vue'
 
 const emit = defineEmits(['paid'])
 
-async function pay() {
-  if (!userData.user.id) return
-  try {
-    await fetch(`${API_BASE}/users/${userData.user.id}/pay`, { method: 'POST' })
-    userData.user.is_member = true
-    emit('paid')
-  } catch (e) {
-    console.error(e)
+function pay() {
+  if (window.showMembershipModal) {
+    window.showMembershipModal();
   }
 }
 

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -1,0 +1,9 @@
+
+def test_create_membership_payment(client, db_session):
+    uid = client.app.state.user_id
+    resp = client.post('/payments/membership', json={'user_id': uid, 'months': 3})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 'payment_url' in data
+    assert f"user={uid}" in data['payment_url']
+    assert "months=3" in data['payment_url']


### PR DESCRIPTION
## Summary
- implement `/payments/membership` endpoint returning a mock payment URL
- expose new payments router in API and main app
- add MembershipModal Vue component
- wire modal into app and expose global helpers
- open MembershipModal from new user screens
- test membership payment endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c758e5ca4832e8420de9684459203