### PR TITLE
Store telegram username on registration

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -83,6 +83,7 @@ async def telegram_auth(request: Request, db: AsyncSession = Depends(get_db)):
                     db,
                     user_id=user_id,
                     agent_number=agent_number,
+                    telegram_username=test_user.get("username"),
                     referrer_id=None,
                 )
                 await crud.create_affiliate(db, user.id)
@@ -121,6 +122,7 @@ async def telegram_auth(request: Request, db: AsyncSession = Depends(get_db)):
             db,
             user_id=user_id,
             agent_number=agent_number,
+            telegram_username=username,
             referrer_id=referrer_id,
         )
         await crud.create_affiliate(db, user.id)

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -40,11 +40,13 @@ async def create_user(
     *,
     user_id: int,
     agent_number: str,
+    telegram_username: str | None = None,
     referrer_id: int | None = None,
 ) -> models.User:
     user = models.User(
         id=user_id,
         agent_number=agent_number,
+        telegram_username=telegram_username,
         join_date=date.today(),
         location="",
         is_member=False,

--- a/backend/models.py
+++ b/backend/models.py
@@ -5,6 +5,7 @@ class User(Base):
     __tablename__ = 'users'
     id = Column(BigInteger, primary_key=True, index=True)
     agent_number = Column(String, unique=True, index=True)
+    telegram_username = Column(String, index=True)
     join_date = Column(Date)
     location = Column(String)
     is_member = Column(Boolean, default=False)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -3,6 +3,7 @@ from datetime import date, datetime
 
 class UserBase(BaseModel):
     agent_number: str
+    telegram_username: str | None = None
     join_date: date | None = None
     location: str | None = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,13 @@ def db_session(client):
             phrase = models.MotivationPhrase(text='Join us now!')
             db.add(phrase)
             await db.commit()
-            user = models.User(id=1000000000000, agent_number='agent', join_date=date(2024, 1, 1), location='Moscow')
+            user = models.User(
+                id=1000000000000,
+                agent_number='agent',
+                telegram_username='test_user',
+                join_date=date(2024, 1, 1),
+                location='Moscow'
+            )
             db.add(user)
             await db.commit()
             await db.refresh(user)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -38,7 +38,7 @@ def test_generate_agent_number(client, db_session):
     async def run():
         async with SessionLocal() as db:
             num1 = await crud.generate_agent_number(db)
-            await crud.create_user(db, user_id=2, agent_number=num1)
+            await crud.create_user(db, user_id=2, agent_number=num1, telegram_username='user2')
             num2 = await crud.generate_agent_number(db)
             return num1, num2
 


### PR DESCRIPTION
## Summary
- add `telegram_username` field to `User`
- store telegram username in `create_user`
- save telegram username on user auth
- adjust tests for new field

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa8c58248832e87ca1dd032c99987